### PR TITLE
feat(context): add progress bar display style option

### DIFF
--- a/.claude-powerline.json
+++ b/.claude-powerline.json
@@ -48,7 +48,8 @@
           },
           "context": {
             "enabled": true,
-            "showPercentageOnly": false
+            "showPercentageOnly": false,
+            "displayStyle": "text"
           },
           "tmux": {
             "enabled": false

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ These people have helped make this project better through bug reports, feature i
 - **[rgfx](https://github.com/rgfx)** - Opened issues and provided new ideas for project improvements
 - **[FallDownTheSystem](https://github.com/FallDownTheSystem)** - Helped debug performance issues on Windows ([ccusage#497](https://github.com/ryoppippi/ccusage/pull/497))
 - **[leependu](https://github.com/leependu)** - Contributed icon customization ideas and well-implemented feature proposal
+- **[ricardo-nth](https://github.com/ricardo-nth)** - Proposed progress bar display for context segment ([#39](https://github.com/Owloops/claude-powerline/pull/39))
 
 ---
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -32,7 +32,7 @@ export const DEFAULT_CONFIG: PowerlineConfig = {
           block: { enabled: false, type: "cost", burnType: "cost" },
           version: { enabled: false },
           tmux: { enabled: false },
-          context: { enabled: true, showPercentageOnly: false },
+          context: { enabled: true, showPercentageOnly: false, displayStyle: "text" },
           metrics: {
             enabled: false,
             showResponseTime: true,

--- a/src/powerline.ts
+++ b/src/powerline.ts
@@ -570,6 +570,8 @@ export class PowerlineRenderer {
       metrics_lines_removed: symbolSet.metrics_lines_removed,
       metrics_burn: symbolSet.metrics_burn,
       version: symbolSet.version,
+      bar_filled: symbolSet.bar_filled,
+      bar_empty: symbolSet.bar_empty,
     };
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -29,6 +29,8 @@ export const SYMBOLS = {
   metrics_lines_removed: "-",
   metrics_burn: "⟢",
   version: "◈",
+  bar_filled: "▪",
+  bar_empty: "▫",
 } as const;
 
 export const TEXT_SYMBOLS = {
@@ -60,5 +62,7 @@ export const TEXT_SYMBOLS = {
   metrics_lines_removed: "-",
   metrics_burn: "~/h",
   version: "V",
+  bar_filled: "=",
+  bar_empty: "-",
 } as const;
 


### PR DESCRIPTION
## Summary

Adds optional progress bar display for context segment, inspired by #39.

- New `displayStyle` config option: `"text"` (default) or `"bar"`
- Bar mode uses small square characters (`▪▫` unicode, `=-` text)
- Bar shows percentage used, text mode shows percentage remaining
- Includes color-coded thresholds from #38

## Example Config

```json
"context": {
  "enabled": true,
  "displayStyle": "bar"
}
```

## Credits

Thanks to @ricardo-nth for the original idea in #39. Added to CONTRIBUTORS.md.

Closes #39