### PR TITLE
feat(rateLimits): add session and weekly rate limit usage segment

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -42,6 +42,7 @@ export const DEFAULT_CONFIG: PowerlineConfig = {
             showLinesAdded: true,
             showLinesRemoved: true,
           },
+          rateLimits: { enabled: false, show: "both", showResetTime: false, showExtraUsage: true },
         },
       },
     ],

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -14,6 +14,7 @@ import type {
   BlockSegmentConfig,
   TodaySegmentConfig,
   VersionSegmentConfig,
+  RateLimitsSegmentConfig,
 } from "../segments/renderer";
 
 export interface LineConfig {
@@ -28,6 +29,7 @@ export interface LineConfig {
     context?: ContextSegmentConfig;
     metrics?: MetricsSegmentConfig;
     version?: VersionSegmentConfig;
+    rateLimits?: RateLimitsSegmentConfig;
   };
 }
 

--- a/src/segments/index.ts
+++ b/src/segments/index.ts
@@ -9,6 +9,7 @@ export {
 } from "./session";
 export { ContextProvider, ContextInfo } from "./context";
 export { MetricsProvider, MetricsInfo } from "./metrics";
+export { RateLimitsProvider, RateLimitsInfo } from "./rateLimits";
 export {
   SegmentRenderer,
   PowerlineSymbols,
@@ -21,4 +22,5 @@ export {
   BlockSegmentConfig,
   TodaySegmentConfig,
   VersionSegmentConfig,
+  RateLimitsSegmentConfig,
 } from "./renderer";

--- a/src/segments/rateLimits.ts
+++ b/src/segments/rateLimits.ts
@@ -1,0 +1,236 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { debug } from "../utils/logger";
+import type { ClaudeHookData } from "../utils/claude";
+
+const USAGE_ENDPOINT = "https://api.anthropic.com/api/oauth/usage";
+const BETA_HEADER = "oauth-2025-04-20";
+const CACHE_TTL_MS = 30_000;
+
+export interface RateLimitsInfo {
+  session?: {
+    usedPercentage: number;
+    resetsAt: string | null;
+  };
+  weekly?: {
+    usedPercentage: number;
+    resetsAt: string | null;
+  };
+  extraUsage?: {
+    enabled: boolean;
+    usedDollars: number;
+    limitDollars: number;
+    currency: string;
+  };
+}
+
+interface OAuthUsageResponse {
+  five_hour?: { utilization?: number; resets_at?: string };
+  seven_day?: { utilization?: number; resets_at?: string };
+  extra_usage?: {
+    is_enabled?: boolean;
+    monthly_limit?: number;
+    used_credits?: number;
+    utilization?: number;
+    currency?: string;
+  };
+}
+
+interface CredentialsFile {
+  claudeAiOauth?: {
+    accessToken?: string;
+    refreshToken?: string;
+    expiresAt?: number;
+    scopes?: string[];
+    rateLimitTier?: string;
+  };
+}
+
+interface CacheEntry {
+  data: RateLimitsInfo;
+  timestamp: number;
+}
+
+export class RateLimitsProvider {
+  private static readonly cacheDir = join(tmpdir(), "claude-powerline");
+  private static readonly cacheFile = join(
+    RateLimitsProvider.cacheDir,
+    "rate-limits-cache.json",
+  );
+
+  async getRateLimitsInfo(
+    hookData: ClaudeHookData,
+  ): Promise<RateLimitsInfo | null> {
+    if (hookData.rate_limits) {
+      const rl = hookData.rate_limits;
+      return {
+        session: rl.session
+          ? {
+              usedPercentage: rl.session.used_percentage,
+              resetsAt: rl.session.resets_at,
+            }
+          : undefined,
+        weekly: rl.weekly
+          ? {
+              usedPercentage: rl.weekly.used_percentage,
+              resetsAt: rl.weekly.resets_at,
+            }
+          : undefined,
+      };
+    }
+
+    return this.fetchFromOAuthAPI();
+  }
+
+  private async fetchFromOAuthAPI(): Promise<RateLimitsInfo | null> {
+    const cached = await this.readCache();
+    if (cached) return cached;
+
+    const token = await this.loadAccessToken();
+    if (!token) {
+      debug("No OAuth access token found");
+      return null;
+    }
+
+    try {
+      const response = await fetch(USAGE_ENDPOINT, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "anthropic-beta": BETA_HEADER,
+          "User-Agent": "claude-powerline",
+        },
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!response.ok) {
+        debug(
+          `OAuth usage API returned ${response.status}: ${response.statusText}`,
+        );
+        return null;
+      }
+
+      const data = (await response.json()) as OAuthUsageResponse;
+      const info = this.parseUsageResponse(data);
+      await this.writeCache(info);
+      return info;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      debug(`Failed to fetch OAuth usage: ${msg}`);
+      return null;
+    }
+  }
+
+  private parseUsageResponse(data: OAuthUsageResponse): RateLimitsInfo {
+    const info: RateLimitsInfo = {};
+
+    if (data.five_hour?.utilization !== undefined) {
+      info.session = {
+        usedPercentage: data.five_hour.utilization,
+        resetsAt: data.five_hour.resets_at ?? null,
+      };
+    }
+
+    if (data.seven_day?.utilization !== undefined) {
+      info.weekly = {
+        usedPercentage: data.seven_day.utilization,
+        resetsAt: data.seven_day.resets_at ?? null,
+      };
+    }
+
+    if (data.extra_usage?.is_enabled) {
+      const usedCents = data.extra_usage.used_credits ?? 0;
+      const limitCents = data.extra_usage.monthly_limit ?? 0;
+      info.extraUsage = {
+        enabled: true,
+        usedDollars: usedCents / 100,
+        limitDollars: limitCents / 100,
+        currency: data.extra_usage.currency?.trim() || "USD",
+      };
+    }
+
+    return info;
+  }
+
+  private async loadAccessToken(): Promise<string | null> {
+    const credentialsPath = join(homedir(), ".claude", ".credentials.json");
+    if (existsSync(credentialsPath)) {
+      try {
+        const content = await readFile(credentialsPath, "utf-8");
+        const creds = JSON.parse(content) as CredentialsFile;
+        const token = creds.claudeAiOauth?.accessToken;
+        if (token) return token;
+      } catch (err) {
+        debug(`Failed to read credentials file: ${err}`);
+      }
+    }
+
+    try {
+      const token = await this.readFromKeychain();
+      if (token) return token;
+    } catch (err) {
+      debug(`Failed to read from keychain: ${err}`);
+    }
+
+    return null;
+  }
+
+  private readFromKeychain(): Promise<string | null> {
+    return new Promise((resolve) => {
+      execFile(
+        "security",
+        ["find-generic-password", "-s", "Claude Code-credentials", "-w"],
+        { timeout: 5000 },
+        (err, stdout) => {
+          if (err || !stdout.trim()) {
+            resolve(null);
+            return;
+          }
+          try {
+            const creds = JSON.parse(stdout.trim()) as CredentialsFile;
+            resolve(creds.claudeAiOauth?.accessToken ?? null);
+          } catch {
+            resolve(null);
+          }
+        },
+      );
+    });
+  }
+
+  private async readCache(): Promise<RateLimitsInfo | null> {
+    try {
+      if (!existsSync(RateLimitsProvider.cacheFile)) return null;
+
+      const content = await readFile(RateLimitsProvider.cacheFile, "utf-8");
+      const entry = JSON.parse(content) as CacheEntry;
+
+      if (Date.now() - entry.timestamp > CACHE_TTL_MS) return null;
+
+      return entry.data;
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeCache(data: RateLimitsInfo): Promise<void> {
+    try {
+      if (!existsSync(RateLimitsProvider.cacheDir)) {
+        await mkdir(RateLimitsProvider.cacheDir, { recursive: true });
+      }
+
+      const entry: CacheEntry = { data, timestamp: Date.now() };
+      await writeFile(
+        RateLimitsProvider.cacheFile,
+        JSON.stringify(entry),
+        "utf-8",
+      );
+    } catch (err) {
+      debug(`Failed to write rate limits cache: ${err}`);
+    }
+  }
+}

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -13,6 +13,9 @@ export const darkTheme: ColorTheme = {
   contextCritical: { bg: "#991b1b", fg: "#fca5a5" },
   metrics: { bg: "#374151", fg: "#d1d5db" },
   version: { bg: "#3a3a4a", fg: "#b8b8d0" },
+  rateLimits: { bg: "#1e3a5f", fg: "#7dd3fc" },
+  rateLimitsWarning: { bg: "#92400e", fg: "#fbbf24" },
+  rateLimitsCritical: { bg: "#991b1b", fg: "#fca5a5" },
 };
 
 export const darkAnsi256Theme: ColorTheme = {
@@ -28,6 +31,9 @@ export const darkAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#870000", fg: "#ff8787" },
   metrics: { bg: "#4e4e4e", fg: "#d0d0d0" },
   version: { bg: "#444444", fg: "#d7afff" },
+  rateLimits: { bg: "#005f87", fg: "#87d7ff" },
+  rateLimitsWarning: { bg: "#af5f00", fg: "#ffaf00" },
+  rateLimitsCritical: { bg: "#870000", fg: "#ff8787" },
 };
 
 export const darkAnsiTheme: ColorTheme = {
@@ -43,4 +49,7 @@ export const darkAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#af0000", fg: "#ff0000" },
   metrics: { bg: "#666666", fg: "#ffffff" },
   version: { bg: "#585858", fg: "#af87ff" },
+  rateLimits: { bg: "#005f87", fg: "#5fafff" },
+  rateLimitsWarning: { bg: "#d75f00", fg: "#ffff00" },
+  rateLimitsCritical: { bg: "#af0000", fg: "#ff0000" },
 };

--- a/src/themes/gruvbox.ts
+++ b/src/themes/gruvbox.ts
@@ -13,6 +13,9 @@ export const gruvboxTheme: ColorTheme = {
   contextCritical: { bg: "#cc241d", fg: "#ebdbb2" },
   metrics: { bg: "#d3869b", fg: "#282828" },
   version: { bg: "#504945", fg: "#8ec07c" },
+  rateLimits: { bg: "#282828", fg: "#83a598" },
+  rateLimitsWarning: { bg: "#d79921", fg: "#282828" },
+  rateLimitsCritical: { bg: "#cc241d", fg: "#ebdbb2" },
 };
 
 export const gruvboxAnsi256Theme: ColorTheme = {
@@ -28,6 +31,9 @@ export const gruvboxAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#d70000", fg: "#ffffaf" },
   metrics: { bg: "#d787af", fg: "#303030" },
   version: { bg: "#585858", fg: "#87af87" },
+  rateLimits: { bg: "#303030", fg: "#87afaf" },
+  rateLimitsWarning: { bg: "#d7af00", fg: "#303030" },
+  rateLimitsCritical: { bg: "#d70000", fg: "#ffffaf" },
 };
 
 export const gruvboxAnsiTheme: ColorTheme = {
@@ -43,4 +49,7 @@ export const gruvboxAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#d70000", fg: "#ffffff" },
   metrics: { bg: "#ff87af", fg: "#444444" },
   version: { bg: "#808080", fg: "#00d787" },
+  rateLimits: { bg: "#444444", fg: "#00afff" },
+  rateLimitsWarning: { bg: "#d7af00", fg: "#000000" },
+  rateLimitsCritical: { bg: "#d70000", fg: "#ffffff" },
 };

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -35,6 +35,9 @@ export interface ColorTheme {
   contextCritical: SegmentColor;
   metrics: SegmentColor;
   version: SegmentColor;
+  rateLimits: SegmentColor;
+  rateLimitsWarning: SegmentColor;
+  rateLimitsCritical: SegmentColor;
 }
 
 export interface PowerlineColors {
@@ -63,6 +66,12 @@ export interface PowerlineColors {
   metricsFg: string;
   versionBg: string;
   versionFg: string;
+  rateLimitsBg: string;
+  rateLimitsFg: string;
+  rateLimitsWarningBg: string;
+  rateLimitsWarningFg: string;
+  rateLimitsCriticalBg: string;
+  rateLimitsCriticalFg: string;
 }
 
 export const BUILT_IN_THEMES: Record<string, ColorTheme> = {

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -13,6 +13,9 @@ export const lightTheme: ColorTheme = {
   contextCritical: { bg: "#dc2626", fg: "#ffffff" },
   metrics: { bg: "#6b7280", fg: "#ffffff" },
   version: { bg: "#8b7dd8", fg: "#ffffff" },
+  rateLimits: { bg: "#0284c7", fg: "#ffffff" },
+  rateLimitsWarning: { bg: "#d97706", fg: "#ffffff" },
+  rateLimitsCritical: { bg: "#dc2626", fg: "#ffffff" },
 };
 
 export const lightAnsi256Theme: ColorTheme = {
@@ -28,6 +31,9 @@ export const lightAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#d70000", fg: "#ffffff" },
   metrics: { bg: "#767676", fg: "#ffffff" },
   version: { bg: "#af87ff", fg: "#ffffff" },
+  rateLimits: { bg: "#0087d7", fg: "#ffffff" },
+  rateLimitsWarning: { bg: "#d78700", fg: "#ffffff" },
+  rateLimitsCritical: { bg: "#d70000", fg: "#ffffff" },
 };
 
 export const lightAnsiTheme: ColorTheme = {
@@ -43,4 +49,7 @@ export const lightAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#d70000", fg: "#ffffff" },
   metrics: { bg: "#767676", fg: "#ffffff" },
   version: { bg: "#af87ff", fg: "#ffffff" },
+  rateLimits: { bg: "#0087d7", fg: "#ffffff" },
+  rateLimitsWarning: { bg: "#d78700", fg: "#ffffff" },
+  rateLimitsCritical: { bg: "#d70000", fg: "#ffffff" },
 };

--- a/src/themes/nord.ts
+++ b/src/themes/nord.ts
@@ -13,6 +13,9 @@ export const nordTheme: ColorTheme = {
   contextCritical: { bg: "#bf616a", fg: "#eceff4" },
   metrics: { bg: "#b48ead", fg: "#2e3440" },
   version: { bg: "#434c5e", fg: "#88c0d0" },
+  rateLimits: { bg: "#2e3440", fg: "#88c0d0" },
+  rateLimitsWarning: { bg: "#d08770", fg: "#2e3440" },
+  rateLimitsCritical: { bg: "#bf616a", fg: "#eceff4" },
 };
 
 export const nordAnsi256Theme: ColorTheme = {
@@ -28,6 +31,9 @@ export const nordAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#d75f5f", fg: "#ffffff" },
   metrics: { bg: "#d787af", fg: "#3a3a3a" },
   version: { bg: "#5f87af", fg: "#5fafaf" },
+  rateLimits: { bg: "#3a3a3a", fg: "#5fafaf" },
+  rateLimitsWarning: { bg: "#d7875f", fg: "#3a3a3a" },
+  rateLimitsCritical: { bg: "#d75f5f", fg: "#ffffff" },
 };
 
 export const nordAnsiTheme: ColorTheme = {
@@ -43,4 +49,7 @@ export const nordAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#d75f5f", fg: "#ffffff" },
   metrics: { bg: "#ff87d7", fg: "#444444" },
   version: { bg: "#0087af", fg: "#00d7d7" },
+  rateLimits: { bg: "#444444", fg: "#00d7d7" },
+  rateLimitsWarning: { bg: "#d78700", fg: "#000000" },
+  rateLimitsCritical: { bg: "#d75f5f", fg: "#ffffff" },
 };

--- a/src/themes/rose-pine.ts
+++ b/src/themes/rose-pine.ts
@@ -13,6 +13,9 @@ export const rosePineTheme: ColorTheme = {
   contextCritical: { bg: "#eb6f92", fg: "#191724" },
   metrics: { bg: "#524f67", fg: "#e0def4" },
   version: { bg: "#2a273f", fg: "#c4a7e7" },
+  rateLimits: { bg: "#1f1d2e", fg: "#9ccfd8" },
+  rateLimitsWarning: { bg: "#f6c177", fg: "#191724" },
+  rateLimitsCritical: { bg: "#eb6f92", fg: "#191724" },
 };
 
 export const rosePineAnsi256Theme: ColorTheme = {
@@ -28,6 +31,9 @@ export const rosePineAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#ff5f87", fg: "#1c1c1c" },
   metrics: { bg: "#767676", fg: "#e4e4e4" },
   version: { bg: "#4e4e4e", fg: "#d787d7" },
+  rateLimits: { bg: "#262626", fg: "#87d7d7" },
+  rateLimitsWarning: { bg: "#d7af5f", fg: "#1c1c1c" },
+  rateLimitsCritical: { bg: "#ff5f87", fg: "#1c1c1c" },
 };
 
 export const rosePineAnsiTheme: ColorTheme = {
@@ -43,4 +49,7 @@ export const rosePineAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#ff5f5f", fg: "#000000" },
   metrics: { bg: "#a8a8a8", fg: "#000000" },
   version: { bg: "#666666", fg: "#ff87ff" },
+  rateLimits: { bg: "#303030", fg: "#00d7d7" },
+  rateLimitsWarning: { bg: "#d7af00", fg: "#000000" },
+  rateLimitsCritical: { bg: "#ff5f5f", fg: "#000000" },
 };

--- a/src/themes/tokyo-night.ts
+++ b/src/themes/tokyo-night.ts
@@ -13,6 +13,9 @@ export const tokyoNightTheme: ColorTheme = {
   contextCritical: { bg: "#f7768e", fg: "#1a1b26" },
   metrics: { bg: "#3d59a1", fg: "#c0caf5" },
   version: { bg: "#292e42", fg: "#bb9af7" },
+  rateLimits: { bg: "#1a1b26", fg: "#7aa2f7" },
+  rateLimitsWarning: { bg: "#ff9e64", fg: "#1a1b26" },
+  rateLimitsCritical: { bg: "#f7768e", fg: "#1a1b26" },
 };
 
 export const tokyoNightAnsi256Theme: ColorTheme = {
@@ -28,6 +31,9 @@ export const tokyoNightAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#ff5f87", fg: "#262626" },
   metrics: { bg: "#5f5faf", fg: "#d7d7ff" },
   version: { bg: "#444460", fg: "#d787ff" },
+  rateLimits: { bg: "#262626", fg: "#5f87ff" },
+  rateLimitsWarning: { bg: "#ffaf5f", fg: "#262626" },
+  rateLimitsCritical: { bg: "#ff5f87", fg: "#262626" },
 };
 
 export const tokyoNightAnsiTheme: ColorTheme = {
@@ -43,4 +49,7 @@ export const tokyoNightAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#ff5f5f", fg: "#000000" },
   metrics: { bg: "#8787d7", fg: "#ffffff" },
   version: { bg: "#585870", fg: "#d787ff" },
+  rateLimits: { bg: "#303050", fg: "#5f87ff" },
+  rateLimitsWarning: { bg: "#ffaf00", fg: "#000000" },
+  rateLimitsCritical: { bg: "#ff5f5f", fg: "#000000" },
 };

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -40,6 +40,16 @@ export interface ClaudeHookData {
       cache_read_input_tokens: number;
     };
   };
+  rate_limits?: {
+    session?: {
+      used_percentage: number;
+      resets_at: string;
+    };
+    weekly?: {
+      used_percentage: number;
+      resets_at: string;
+    };
+  };
 }
 
 export function getClaudePaths(): string[] {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -29,6 +29,8 @@ export const SYMBOLS = {
   metrics_lines_removed: "-",
   metrics_burn: "⟢",
   version: "◈",
+  rate_limits_session: "⏱",
+  rate_limits_weekly: "⏳",
   bar_filled: "▪",
   bar_empty: "▫",
 } as const;
@@ -62,6 +64,8 @@ export const TEXT_SYMBOLS = {
   metrics_lines_removed: "-",
   metrics_burn: "~/h",
   version: "V",
+  rate_limits_session: "S%",
+  rate_limits_weekly: "W%",
   bar_filled: "=",
   bar_empty: "-",
 } as const;


### PR DESCRIPTION
## Summary

Adds a new `rateLimits` segment that displays the current session (5-hour) and weekly (7-day) rate limit usage percentages directly in the powerline, with optional reset countdown timers and extra usage (monthly spend) display.

**Example output:** `⏱ 100% (1h 41m) ⏳ 44% (4d 12h) $24.10/$42.50`

## Data Source

Claude Code's `statusLine` hook data does **not** currently include rate limit information — there is an [open feature request](https://github.com/anthropics/claude-code/issues/20636) and a [related issue](https://github.com/anthropics/claude-code/issues/23011) on the Claude Code repo, but neither has been implemented as of v2.0.65.

To work around this, this PR fetches rate limit data directly from the **Anthropic OAuth Usage API**:

```
GET https://api.anthropic.com/api/oauth/usage
Authorization: Bearer <access_token>
anthropic-beta: oauth-2025-04-20
```

The response provides:
- `five_hour.utilization` → session window percentage + reset time
- `seven_day.utilization` → weekly window percentage + reset time
- `extra_usage` → monthly spend/limit (if enabled on the account)

This is the same endpoint and approach used by [CodexBar](https://github.com/steipete/CodexBar) (MIT, by Peter Steinberger), a macOS menu bar app that displays Claude usage. Relevant implementation details are documented in [CodexBar's Claude provider docs](https://github.com/steipete/CodexBar/blob/main/docs/claude.md).

### Future-proofing

The implementation also checks for native `hookData.rate_limits` first. If Claude Code ever adds rate limit data to the statusLine hook (per the feature requests above), the segment will use it directly without needing API calls.

## Credential Resolution

The OAuth access token is resolved in this order:

1. **File-based:** `~/.claude/.credentials.json` → `claudeAiOauth.accessToken`
2. **macOS Keychain:** service `"Claude Code-credentials"` via `security find-generic-password`

This matches how Claude Code itself stores credentials — on macOS the Keychain is the primary location, while the file is used on Linux.

## Caching

Since each statusline invocation is a fresh process, API responses are cached to a file (`/tmp/claude-powerline/rate-limits-cache.json`) with a 30-second TTL to avoid excessive API calls.

## Configuration

```json
"rateLimits": {
  "enabled": true,
  "show": "both",
  "showResetTime": true,
  "showExtraUsage": true
}
```

| Option | Values | Default | Description |
|--------|--------|---------|-------------|
| `show` | `"both"` \| `"session"` \| `"weekly"` | `"both"` | Which rate limits to display |
| `showResetTime` | `boolean` | `false` | Show countdown to reset (e.g., `1h 41m`) |
| `showExtraUsage` | `boolean` | `true` | Show monthly extra usage spend |

Disabled by default — users opt in via config.

## Color Theming

Three color tiers with thresholds matching the existing budget segment pattern:
- **Normal** — usage < 50%
- **Warning** — usage ≥ 50%
- **Critical** — usage ≥ 80%

Colors added to all 6 built-in themes (dark, light, nord, tokyo-night, rose-pine, gruvbox) across all 3 color modes (truecolor, ansi256, ansi).

## Symbols

| Mode | Session | Weekly |
|------|---------|--------|
| Unicode | `⏱` | `⏳` |
| Text | `S%` | `W%` |

## Files Changed

- **New:** `src/segments/rateLimits.ts` — OAuth API provider with credential resolution + file cache
- `src/segments/renderer.ts` — `renderRateLimits()` method + config interface
- `src/powerline.ts` — Provider wiring through the render pipeline
- `src/config/defaults.ts` + `src/config/loader.ts` — Default config + type
- `src/utils/claude.ts` — `rate_limits` field on hook data interface (for future native support)
- `src/utils/constants.ts` — Symbols
- `src/themes/index.ts` + all 6 theme files — Color definitions
- `src/segments/index.ts` — Exports

## Acknowledgments

- [CodexBar](https://github.com/steipete/CodexBar) by [@steipete](https://github.com/steipete) — OAuth API approach, credential resolution strategy, and endpoint documentation
- Claude Code issues [#20636](https://github.com/anthropics/claude-code/issues/20636) and [#23011](https://github.com/anthropics/claude-code/issues/23011) — context on native rate_limits support status

## Creation

This pull request was written with the help of Claude Opus 4.6 on Claude Code v2.1.36, with full access of both the claude-powerline and CodexBar repositories. Code cleaned up by the [code-simplifier skill](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/code-simplifier/agents/code-simplifier.md)