### PR TITLE
feat(context): add progress bar display styles for context segment

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ These people have helped make this project better through bug reports, feature i
 - **[FallDownTheSystem](https://github.com/FallDownTheSystem)** - Helped debug performance issues on Windows ([ccusage#497](https://github.com/ryoppippi/ccusage/pull/497))
 - **[leependu](https://github.com/leependu)** - Contributed icon customization ideas and well-implemented feature proposal
 - **[ricardo-nth](https://github.com/ricardo-nth)** - Proposed progress bar display for context segment ([#39](https://github.com/Owloops/claude-powerline/pull/39))
+- **[uberkael](https://github.com/uberkael)** - Added progress bar display styles for context segment ([#48](https://github.com/Owloops/claude-powerline/pull/48))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -286,15 +286,30 @@ Config files reload automatically and no restart needed.
 ```json
 "context": {
   "enabled": true,
-  "showPercentageOnly": false
+  "showPercentageOnly": false,
+  "displayStyle": "text"
 }
 ```
 
 **Options:**
 
 - `showPercentageOnly`: Show only percentage remaining (default: false)
+- `displayStyle`: Visual style for context display (default: `"text"`)
 
-**Display:** `◔ 34,040 (79%)` or `◔ 79%` (percentage only)
+**Display Styles:**
+
+| Style | Example | Description |
+|-------|---------|-------------|
+| `text` | `◔ 34,040 (79%)` | Text with token count (default) |
+| `bar` | `▪▪▪▪▫▫▫▫▫▫ 40%` | Bar using theme symbols |
+| `blocks` | `████░░░░░░ 40%` | Solid/shaded blocks |
+| `squares` | `◼◼◼◼◻◻◻◻◻◻ 40%` | Filled/empty squares |
+| `dots` | `●●●●○○○○○○ 40%` | Filled/empty circles |
+| `line` | `━━━━┄┄┄┄┄┄ 40%` | Thick/dashed line |
+| `capped` | `━━━╸┄┄┄┄┄┄ 40%` | Line with boundary cap |
+| `ball` | `───●────── 40%` | Position marker on a track |
+| `filled` | `■■■■□□□□□□ 40%` | Filled/empty squares (alt) |
+| `geometric` | `▰▰▰▰▱▱▱▱▱▱ 40%` | Geometric triangles |
 
 **Symbols:** `◔` Context (unicode) • `C` Context (text)
 


### PR DESCRIPTION
## Summary

Adds 8 new visual bar styles for the context segment, extending the existing `displayStyle` option alongside `text` and `bar`.

Based on @uberkael's work in #48 with the following changes:

- **Deduplicated rendering logic** — The `bar` style and custom styles now share a single code path via a unified `BarStyleDef` lookup and a `buildBar()` helper method, removing ~40 lines of duplicated fill/empty/color logic
- **Extracted `BAR_STYLES` to module-level constant** — Previously rebuilt inside `renderContext()` on every call
- **Added tests** — 8 focused tests covering text/bar fallback, all standard styles, capped edge cases (0%/mid/100%), ball marker, null context, warning/critical colors, and `showPercentageOnly`
- **Updated README** — Documented `displayStyle` option with a table of all 10 styles and examples
- **Added contributor credit** — Added @uberkael to CONTRIBUTORS.md

**Available styles:**

| Style | Filled | Empty | Example |
|-------|--------|-------|---------|
| `blocks` | █ | ░ | `████░░░░░░` |
| `squares` | ◼ | ◻ | `◼◼◼◼◻◻◻◻◻◻` |
| `dots` | ● | ○ | `●●●●○○○○○○` |
| `line` | ━ | ┄ | `━━━━┄┄┄┄┄┄` |
| `capped` | ━ | ┄ | `━━━╸┄┄┄┄┄┄` |
| `ball` | ─ | ─ | `───●──────` |
| `filled` | ■ | □ | `■■■■□□□□□□` |
| `geometric` | ▰ | ▱ | `▰▰▰▰▱▱▱▱▱▱` |

Supersedes #48.

## Test plan
- [x] All existing tests pass
- [x] New context bar style tests pass (16 total in segment suite)
- [x] TypeScript compiles cleanly
- [x] Verify each style renders correctly in terminal
- [x] Verify `capped` and `ball` edge cases (0%, 100%)