### PR TITLE
fix: check both ~/.config/claude and ~/.claude paths

### DIFF
--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -62,7 +62,8 @@ export function getClaudePaths(): string[] {
 
     if (existsSync(configPath)) {
       paths.push(configPath);
-    } else if (existsSync(claudePath)) {
+    }
+    if (existsSync(claudePath)) {
       paths.push(claudePath);
     }
   }


### PR DESCRIPTION
## Summary

- Fix `getClaudePaths()` using `if/else` that skips `~/.claude` when `~/.config/claude` exists
- Change to two independent `if` checks so both directories are searched
- Prevents silent data loss when `~/.config/claude` exists but is empty while actual data lives in `~/.claude`

Closes #47

## Test plan

- [ ] Verify with both `~/.config/claude` and `~/.claude` present — both should be searched
- [ ] Verify with only `~/.config/claude` — still works as before
- [ ] Verify with only `~/.claude` — still works as before
- [ ] Verify with `CLAUDE_CONFIG_DIR` env var set — env var path takes precedence (unchanged behavior)