### PR TITLE
fix(tests): cross-platform path handling in config tests

### DIFF
--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import os from "node:os";
+import path from "node:path";
 import { DEFAULT_CONFIG } from "../src/config/defaults";
 import { loadConfig, loadConfigFromCLI } from "../src/config/loader";
 
@@ -34,7 +35,7 @@ describe("config", () => {
     it("should merge project config over defaults", () => {
       const projectConfig = { theme: "dark" };
       mockFs.existsSync.mockImplementation(
-        (path) => path === "/project/.claude-powerline.json"
+        (p) => p === path.join("/project", ".claude-powerline.json")
       );
       mockFs.readFileSync.mockReturnValue(JSON.stringify(projectConfig));
 
@@ -201,7 +202,7 @@ describe("config", () => {
 
     it("should prioritize CLI over environment over file", () => {
       mockFs.existsSync.mockImplementation(
-        (path) => path === "/project/.claude-powerline.json"
+        (p) => p === path.join("/project", ".claude-powerline.json")
       );
       mockFs.readFileSync.mockReturnValue(
         JSON.stringify({ theme: "light", display: { style: "minimal" } })
@@ -229,7 +230,7 @@ describe("config", () => {
     it("should fallback invalid theme in config file to dark", () => {
       const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
       mockFs.existsSync.mockImplementation(
-        (path) => path === "/project/.claude-powerline.json"
+        (p) => p === path.join("/project", ".claude-powerline.json")
       );
       mockFs.readFileSync.mockReturnValue(
         JSON.stringify({ theme: "invalid-theme" })
@@ -246,7 +247,7 @@ describe("config", () => {
     it("should fallback invalid style in config file to minimal", () => {
       const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
       mockFs.existsSync.mockImplementation(
-        (path) => path === "/project/.claude-powerline.json"
+        (p) => p === path.join("/project", ".claude-powerline.json")
       );
       mockFs.readFileSync.mockReturnValue(
         JSON.stringify({ display: { style: "invalid-style" } })
@@ -262,7 +263,7 @@ describe("config", () => {
 
     it("should accept capsule style in config file", () => {
       mockFs.existsSync.mockImplementation(
-        (path) => path === "/project/.claude-powerline.json"
+        (p) => p === path.join("/project", ".claude-powerline.json")
       );
       mockFs.readFileSync.mockReturnValue(
         JSON.stringify({ display: { style: "capsule" } })


### PR DESCRIPTION
## Summary

- Fix 3 failing tests and 2 silently broken tests in `test/config.test.ts`
- Root cause: `existsSync` mocks compared against hardcoded Unix paths (`/project/.claude-powerline.json`), but the source code uses `path.join()` which produces backslash paths on Windows (`\project\.claude-powerline.json`) — the paths never matched
- Use `path.join()` in mock comparisons to match what the source code does

## Details

| Test | Before (Windows) | Issue |
|------|-----------------|-------|
| "should fallback invalid theme in config file to dark" | FAIL | `console.warn` never called |
| "should fallback invalid style in config file to minimal" | FAIL | `console.warn` never called |
| "should accept capsule style in config file" | FAIL | style stayed `"minimal"` |
| "should merge project config over defaults" | PASS (by coincidence) | Config never loaded, but defaults matched |
| "should prioritize CLI over environment over file" | PASS (by coincidence) | CLI overrides won regardless |

## Test plan

- [x] All 90 tests pass on Windows
- [ ] Verify tests still pass on Linux/macOS (path.join produces forward slashes there, matching the previous behavior)