### PR TITLE
fix(session): look in `<session-uuid>/subagents/` for agent transcripts

### DIFF
--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -119,12 +119,14 @@ export async function findAgentTranscripts(
 ): Promise<string[]> {
   const agentFiles: string[] = [];
 
+  const subagentsDir = posix.join(projectPath, sessionId, "subagents");
+
   try {
-    const files = await readdir(projectPath);
+    const files = await readdir(subagentsDir);
     const agentFileNames = files.filter((f) => f.startsWith("agent-") && f.endsWith(".jsonl"));
 
     for (const fileName of agentFileNames) {
-      const filePath = posix.join(projectPath, fileName);
+      const filePath = posix.join(subagentsDir, fileName);
       try {
         const content = await readFile(filePath, "utf-8");
         const firstLine = content.split("\n")[0];
@@ -139,7 +141,7 @@ export async function findAgentTranscripts(
       }
     }
   } catch (error) {
-    debug(`Failed to read project directory ${projectPath}:`, error);
+    debug(`Failed to read subagents directory ${subagentsDir}:`, error);
   }
 
   return agentFiles;

--- a/test/claude-utils.test.ts
+++ b/test/claude-utils.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { findAgentTranscripts } from "../src/utils/claude";
+
+describe("findAgentTranscripts", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "powerline-agent-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function makeSubagentsDir(sessionId: string): string {
+    const subagentsDir = join(tempDir, sessionId, "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    return subagentsDir;
+  }
+
+  function writeAgentFile(subagentsDir: string, name: string, sessionId: string): string {
+    const filePath = join(subagentsDir, name);
+    writeFileSync(filePath, JSON.stringify({ sessionId }) + "\n");
+    return filePath;
+  }
+
+  it("finds agent transcripts in <session-uuid>/subagents/", async () => {
+    const sessionId = "abc123";
+    const subagentsDir = makeSubagentsDir(sessionId);
+    const agentFile = writeAgentFile(subagentsDir, "agent-a1b2c3.jsonl", sessionId);
+
+    const result = await findAgentTranscripts(sessionId, tempDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(agentFile);
+  });
+
+  it("returns [] when session has no subagents directory", async () => {
+    const sessionId = "abc123";
+    mkdirSync(join(tempDir, sessionId)); // session dir exists, but no subagents/ inside
+
+    const result = await findAgentTranscripts(sessionId, tempDir);
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when session directory does not exist at all", async () => {
+    const result = await findAgentTranscripts("no-such-session", tempDir);
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns multiple files when session has multiple agent transcripts", async () => {
+    const sessionId = "abc123";
+    const subagentsDir = makeSubagentsDir(sessionId);
+    writeAgentFile(subagentsDir, "agent-aaa.jsonl", sessionId);
+    writeAgentFile(subagentsDir, "agent-bbb.jsonl", sessionId);
+
+    const result = await findAgentTranscripts(sessionId, tempDir);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("skips files whose first-line sessionId does not match (defensive guard)", async () => {
+    const sessionId = "abc123";
+    const subagentsDir = makeSubagentsDir(sessionId);
+    writeAgentFile(subagentsDir, "agent-x1y2z3.jsonl", "other-session");
+
+    const result = await findAgentTranscripts(sessionId, tempDir);
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips non-agent- files and non-.jsonl files in the subagents dir", async () => {
+    const sessionId = "abc123";
+    const subagentsDir = makeSubagentsDir(sessionId);
+    writeAgentFile(subagentsDir, "agent-valid.jsonl", sessionId);
+    writeFileSync(join(subagentsDir, "agent-ignored.txt"), JSON.stringify({ sessionId }) + "\n");
+    writeFileSync(join(subagentsDir, "other.jsonl"), JSON.stringify({ sessionId }) + "\n");
+
+    const result = await findAgentTranscripts(sessionId, tempDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain("agent-valid.jsonl");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes `findAgentTranscripts()` in `src/utils/claude.ts` to look in `<project-root>/<session-uuid>/subagents/` instead of the project root
- The project root never contains `agent-*.jsonl` files directly — Claude Code always nests them under `<session-uuid>/subagents/` — so the function was always returning `[]`, silently missing all subagent token counts from the `session` segment
- The existing per-file `sessionId` guard is kept as a defensive check (now redundant given the scoped path, but harmless)
- Adds `test/claude-utils.test.ts` with 6 focused tests covering the happy path, graceful fallback when the directory is absent, multiple files, and the defensive `sessionId` guard

Closes #53

## Test plan

- [x] New `findAgentTranscripts` tests pass (6/6)
- [x] Full test suite passes with no regressions (96/96 across 9 suites)
- [x] Verified against real Claude Code transcript layout on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)