### PR TITLE
fix(ci): use GH_TOKEN to bypass branch protection for automated pushes

### DIFF
--- a/.github/workflows/pricing.yml
+++ b/.github/workflows/pricing.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -60,6 +61,6 @@ jobs:
       
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary

- Switch both workflows from `GITHUB_TOKEN` to `GH_TOKEN` (a PAT with Contents write permission)
- `GITHUB_TOKEN` is blocked by the branch protection rule requiring PRs for all pushes
- `GH_TOKEN` is a fine-grained PAT scoped to this repo that can bypass the rule

## Affected workflows

- `release.yml` — semantic-release pushes `package.json` + `CHANGELOG.md` back to main
- `pricing.yml` — weekly pricing update commits `pricing.json` directly to main

## Test plan

- [ ] Trigger a release and verify semantic-release can push back to main
- [ ] Trigger pricing workflow manually and verify it can commit and push