### PR TITLE
feat: add env segment to display environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,28 @@ Configure context window limits for different model types. Defaults to 200K toke
 
 </details>
 
+<details>
+<summary><strong>Env</strong> - Shows the value of an environment variable</summary>
+
+```json
+"env": {
+  "enabled": true,
+  "variable": "CLAUDE_ACCOUNT",
+  "prefix": "Acct"
+}
+```
+
+**Options:**
+
+- `variable` (required): Environment variable name to read
+- `prefix`: Label shown before the value. Defaults to the variable name
+
+Hidden when the variable is unset or empty.
+
+**Symbols:** `⚙` Env (unicode) • `$` Env (text)
+
+</details>
+
 ### Budget Configuration
 
 ```json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owloops/claude-powerline",
-  "version": "1.14.0",
+  "version": "1.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owloops/claude-powerline",
-      "version": "1.14.0",
+      "version": "1.17.2",
       "license": "MIT",
       "bin": {
         "claude-powerline": "dist/index.js"

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -14,6 +14,7 @@ import type {
   BlockSegmentConfig,
   TodaySegmentConfig,
   VersionSegmentConfig,
+  EnvSegmentConfig,
 } from "../segments/renderer";
 
 export interface LineConfig {
@@ -28,6 +29,7 @@ export interface LineConfig {
     context?: ContextSegmentConfig;
     metrics?: MetricsSegmentConfig;
     version?: VersionSegmentConfig;
+    env?: EnvSegmentConfig;
   };
 }
 

--- a/src/powerline.ts
+++ b/src/powerline.ts
@@ -29,6 +29,7 @@ import {
   BlockSegmentConfig,
   TodaySegmentConfig,
   VersionSegmentConfig,
+  EnvSegmentConfig,
 } from "./segments";
 import { BlockProvider, BlockInfo } from "./segments/block";
 import { TodayProvider, TodayInfo } from "./segments/today";
@@ -419,6 +420,10 @@ export class PowerlineRenderer {
       );
     }
 
+    if (segment.type === "env") {
+      return this.segmentRenderer.renderEnv(colors, segment.config as EnvSegmentConfig);
+    }
+
     return null;
   }
 
@@ -552,6 +557,7 @@ export class PowerlineRenderer {
       version: symbolSet.version,
       bar_filled: symbolSet.bar_filled,
       bar_empty: symbolSet.bar_empty,
+      env: symbolSet.env,
     };
   }
 
@@ -619,6 +625,7 @@ export class PowerlineRenderer {
     const contextCritical = getSegmentColors("contextCritical");
     const metrics = getSegmentColors("metrics");
     const version = getSegmentColors("version");
+    const env = getSegmentColors("env");
 
     return {
       reset: colorSupport === "none" ? "" : RESET_CODE,
@@ -646,6 +653,8 @@ export class PowerlineRenderer {
       metricsFg: metrics.fg,
       versionBg: version.bg,
       versionFg: version.fg,
+      envBg: env.bg,
+      envFg: env.fg,
     };
   }
 
@@ -674,6 +683,8 @@ export class PowerlineRenderer {
         return colors.metricsBg;
       case "version":
         return colors.versionBg;
+      case "env":
+        return colors.envBg;
       default:
         return colors.modeBg;
     }

--- a/src/segments/index.ts
+++ b/src/segments/index.ts
@@ -21,4 +21,5 @@ export {
   BlockSegmentConfig,
   TodaySegmentConfig,
   VersionSegmentConfig,
+  EnvSegmentConfig,
 } from "./renderer";

--- a/src/segments/renderer.ts
+++ b/src/segments/renderer.ts
@@ -58,6 +58,11 @@ export interface TodaySegmentConfig extends SegmentConfig {
 
 export interface VersionSegmentConfig extends SegmentConfig {}
 
+export interface EnvSegmentConfig extends SegmentConfig {
+  variable: string;
+  prefix?: string;
+}
+
 export type AnySegmentConfig =
   | SegmentConfig
   | DirectorySegmentConfig
@@ -68,7 +73,8 @@ export type AnySegmentConfig =
   | MetricsSegmentConfig
   | BlockSegmentConfig
   | TodaySegmentConfig
-  | VersionSegmentConfig;
+  | VersionSegmentConfig
+  | EnvSegmentConfig;
 
 import {
   formatCost,
@@ -117,6 +123,7 @@ export interface PowerlineSymbols {
   version: string;
   bar_filled: string;
   bar_empty: string;
+  env: string;
 }
 
 export interface SegmentData {
@@ -777,5 +784,18 @@ export class SegmentRenderer {
       bgColor: colors.versionBg,
       fgColor: colors.versionFg,
     };
+  }
+
+  renderEnv(
+    colors: PowerlineColors,
+    config: EnvSegmentConfig,
+  ): SegmentData | null {
+    const value = process.env[config.variable];
+    if (!value) return null;
+    const prefix = config.prefix ?? config.variable;
+    const text = prefix
+      ? `${this.symbols.env} ${prefix}: ${value}`
+      : `${this.symbols.env} ${value}`;
+    return { text, bgColor: colors.envBg, fgColor: colors.envFg };
   }
 }

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -13,6 +13,7 @@ export const darkTheme: ColorTheme = {
   contextCritical: { bg: "#991b1b", fg: "#fca5a5" },
   metrics: { bg: "#374151", fg: "#d1d5db" },
   version: { bg: "#3a3a4a", fg: "#b8b8d0" },
+  env: { bg: "#2d2d3d", fg: "#d0a0d0" },
 };
 
 export const darkAnsi256Theme: ColorTheme = {
@@ -28,6 +29,7 @@ export const darkAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#870000", fg: "#ff8787" },
   metrics: { bg: "#4e4e4e", fg: "#d0d0d0" },
   version: { bg: "#444444", fg: "#d7afff" },
+  env: { bg: "#3a3a3a", fg: "#d787d7" },
 };
 
 export const darkAnsiTheme: ColorTheme = {
@@ -43,4 +45,5 @@ export const darkAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#af0000", fg: "#ff0000" },
   metrics: { bg: "#666666", fg: "#ffffff" },
   version: { bg: "#585858", fg: "#af87ff" },
+  env: { bg: "#444444", fg: "#ff87ff" },
 };

--- a/src/themes/gruvbox.ts
+++ b/src/themes/gruvbox.ts
@@ -13,6 +13,7 @@ export const gruvboxTheme: ColorTheme = {
   contextCritical: { bg: "#cc241d", fg: "#ebdbb2" },
   metrics: { bg: "#d3869b", fg: "#282828" },
   version: { bg: "#504945", fg: "#8ec07c" },
+  env: { bg: "#3c3836", fg: "#d3869b" },
 };
 
 export const gruvboxAnsi256Theme: ColorTheme = {
@@ -28,6 +29,7 @@ export const gruvboxAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#d70000", fg: "#ffffaf" },
   metrics: { bg: "#d787af", fg: "#303030" },
   version: { bg: "#585858", fg: "#87af87" },
+  env: { bg: "#444444", fg: "#d787af" },
 };
 
 export const gruvboxAnsiTheme: ColorTheme = {
@@ -43,4 +45,5 @@ export const gruvboxAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#d70000", fg: "#ffffff" },
   metrics: { bg: "#ff87af", fg: "#444444" },
   version: { bg: "#808080", fg: "#00d787" },
+  env: { bg: "#585858", fg: "#ff87af" },
 };

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -35,6 +35,7 @@ export interface ColorTheme {
   contextCritical: SegmentColor;
   metrics: SegmentColor;
   version: SegmentColor;
+  env: SegmentColor;
 }
 
 export interface PowerlineColors {
@@ -63,6 +64,8 @@ export interface PowerlineColors {
   metricsFg: string;
   versionBg: string;
   versionFg: string;
+  envBg: string;
+  envFg: string;
 }
 
 export const BUILT_IN_THEMES: Record<string, ColorTheme> = {

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -13,6 +13,7 @@ export const lightTheme: ColorTheme = {
   contextCritical: { bg: "#dc2626", fg: "#ffffff" },
   metrics: { bg: "#6b7280", fg: "#ffffff" },
   version: { bg: "#8b7dd8", fg: "#ffffff" },
+  env: { bg: "#d45dbf", fg: "#ffffff" },
 };
 
 export const lightAnsi256Theme: ColorTheme = {
@@ -28,6 +29,7 @@ export const lightAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#d70000", fg: "#ffffff" },
   metrics: { bg: "#767676", fg: "#ffffff" },
   version: { bg: "#af87ff", fg: "#ffffff" },
+  env: { bg: "#d787af", fg: "#ffffff" },
 };
 
 export const lightAnsiTheme: ColorTheme = {
@@ -43,4 +45,5 @@ export const lightAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#d70000", fg: "#ffffff" },
   metrics: { bg: "#767676", fg: "#ffffff" },
   version: { bg: "#af87ff", fg: "#ffffff" },
+  env: { bg: "#d787af", fg: "#ffffff" },
 };

--- a/src/themes/nord.ts
+++ b/src/themes/nord.ts
@@ -13,6 +13,7 @@ export const nordTheme: ColorTheme = {
   contextCritical: { bg: "#bf616a", fg: "#eceff4" },
   metrics: { bg: "#b48ead", fg: "#2e3440" },
   version: { bg: "#434c5e", fg: "#88c0d0" },
+  env: { bg: "#3b4252", fg: "#b48ead" },
 };
 
 export const nordAnsi256Theme: ColorTheme = {
@@ -28,6 +29,7 @@ export const nordAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#d75f5f", fg: "#ffffff" },
   metrics: { bg: "#d787af", fg: "#3a3a3a" },
   version: { bg: "#5f87af", fg: "#5fafaf" },
+  env: { bg: "#4e4e4e", fg: "#d787af" },
 };
 
 export const nordAnsiTheme: ColorTheme = {
@@ -43,4 +45,5 @@ export const nordAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#d75f5f", fg: "#ffffff" },
   metrics: { bg: "#ff87d7", fg: "#444444" },
   version: { bg: "#0087af", fg: "#00d7d7" },
+  env: { bg: "#585858", fg: "#ff87af" },
 };

--- a/src/themes/rose-pine.ts
+++ b/src/themes/rose-pine.ts
@@ -13,6 +13,7 @@ export const rosePineTheme: ColorTheme = {
   contextCritical: { bg: "#eb6f92", fg: "#191724" },
   metrics: { bg: "#524f67", fg: "#e0def4" },
   version: { bg: "#2a273f", fg: "#c4a7e7" },
+  env: { bg: "#21202e", fg: "#eb6f92" },
 };
 
 export const rosePineAnsi256Theme: ColorTheme = {
@@ -28,6 +29,7 @@ export const rosePineAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#ff5f87", fg: "#1c1c1c" },
   metrics: { bg: "#767676", fg: "#e4e4e4" },
   version: { bg: "#4e4e4e", fg: "#d787d7" },
+  env: { bg: "#303030", fg: "#ff5f87" },
 };
 
 export const rosePineAnsiTheme: ColorTheme = {
@@ -43,4 +45,5 @@ export const rosePineAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#ff5f5f", fg: "#000000" },
   metrics: { bg: "#a8a8a8", fg: "#000000" },
   version: { bg: "#666666", fg: "#ff87ff" },
+  env: { bg: "#444444", fg: "#ff5f87" },
 };

--- a/src/themes/tokyo-night.ts
+++ b/src/themes/tokyo-night.ts
@@ -13,6 +13,7 @@ export const tokyoNightTheme: ColorTheme = {
   contextCritical: { bg: "#f7768e", fg: "#1a1b26" },
   metrics: { bg: "#3d59a1", fg: "#c0caf5" },
   version: { bg: "#292e42", fg: "#bb9af7" },
+  env: { bg: "#24283b", fg: "#fca7ea" },
 };
 
 export const tokyoNightAnsi256Theme: ColorTheme = {
@@ -28,6 +29,7 @@ export const tokyoNightAnsi256Theme: ColorTheme = {
   contextCritical: { bg: "#ff5f87", fg: "#262626" },
   metrics: { bg: "#5f5faf", fg: "#d7d7ff" },
   version: { bg: "#444460", fg: "#d787ff" },
+  env: { bg: "#303050", fg: "#ff87ff" },
 };
 
 export const tokyoNightAnsiTheme: ColorTheme = {
@@ -43,4 +45,5 @@ export const tokyoNightAnsiTheme: ColorTheme = {
   contextCritical: { bg: "#ff5f5f", fg: "#000000" },
   metrics: { bg: "#8787d7", fg: "#ffffff" },
   version: { bg: "#585870", fg: "#d787ff" },
+  env: { bg: "#444470", fg: "#ff87ff" },
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -31,6 +31,7 @@ export const SYMBOLS = {
   version: "◈",
   bar_filled: "▪",
   bar_empty: "▫",
+  env: "⚙",
 } as const;
 
 export const TEXT_SYMBOLS = {
@@ -64,5 +65,6 @@ export const TEXT_SYMBOLS = {
   version: "V",
   bar_filled: "=",
   bar_empty: "-",
+  env: "$",
 } as const;
 

--- a/test/segments.test.ts
+++ b/test/segments.test.ts
@@ -258,6 +258,74 @@ describe("Segment Time Logic", () => {
     });
   });
 
+  describe("Env Segment", () => {
+    const config = { theme: "dark", display: { style: "minimal" } } as any;
+    const symbols = { env: "⚙" } as any;
+    const colors = { envBg: "#2d2d3d", envFg: "#d0a0d0" } as any;
+
+    let renderer: SegmentRenderer;
+
+    beforeEach(() => {
+      renderer = new SegmentRenderer(config, symbols);
+    });
+
+    afterEach(() => {
+      delete process.env.TEST_ENV_SEGMENT;
+    });
+
+    it("should return null when env var is unset", () => {
+      delete process.env.TEST_ENV_SEGMENT;
+      const result = renderer.renderEnv(colors, {
+        enabled: true,
+        variable: "TEST_ENV_SEGMENT",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("should return null when env var is empty string", () => {
+      process.env.TEST_ENV_SEGMENT = "";
+      const result = renderer.renderEnv(colors, {
+        enabled: true,
+        variable: "TEST_ENV_SEGMENT",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("should render with variable name as default prefix", () => {
+      process.env.TEST_ENV_SEGMENT = "my-value";
+      const result = renderer.renderEnv(colors, {
+        enabled: true,
+        variable: "TEST_ENV_SEGMENT",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.text).toBe("⚙ TEST_ENV_SEGMENT: my-value");
+      expect(result!.bgColor).toBe(colors.envBg);
+      expect(result!.fgColor).toBe(colors.envFg);
+    });
+
+    it("should render with custom prefix", () => {
+      process.env.TEST_ENV_SEGMENT = "work-org";
+      const result = renderer.renderEnv(colors, {
+        enabled: true,
+        variable: "TEST_ENV_SEGMENT",
+        prefix: "Acct",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.text).toBe("⚙ Acct: work-org");
+    });
+
+    it("should render without prefix or colon when prefix is empty string", () => {
+      process.env.TEST_ENV_SEGMENT = "work-org";
+      const result = renderer.renderEnv(colors, {
+        enabled: true,
+        variable: "TEST_ENV_SEGMENT",
+        prefix: "",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.text).toBe("⚙ work-org");
+    });
+  });
+
   describe("Context Segment Bar Styles", () => {
     const config = { theme: "dark", display: { style: "minimal" } } as any;
     const symbols = {


### PR DESCRIPTION
## Summary
- New `env` segment that reads any environment variable and displays its value in the statusline
- Follows the same pattern as existing segments (theme colors, separators, symbol sets)
- If the env var is unset or empty, the segment is hidden

## Config

```json
"env": {
  "enabled": true,
  "variable": "CLAUDE_ACCOUNT",
  "prefix": "Acct"
}
```

- `variable` (required): env var name to read
- `prefix` (optional): label shown before the value. Defaults to the variable name. Set to `""` to show only the value (no label or colon)
- `enabled`: standard segment toggle

## Symbols

| Mode | Symbol | Reasoning |
|------|--------|-----------|
| Unicode | `⚙` | Cog/gear, conveys "configuration" and fits the purpose of displaying environment settings |
| Text | `$` | Standard shell convention for environment variables (`$MY_VAR`) |

Open to suggestions on these. Happy to change them if there are better fits for the project's visual language.

## Use case

Originally discussed in #42. Useful for distinguishing between accounts/profiles when running multiple Claude configs, or displaying any custom context (environment name, team, region, etc.).

## Files changed

- `src/utils/constants.ts`: symbol (`⚙` / `$`)
- `src/themes/index.ts`: `env` added to `ColorTheme` and `PowerlineColors`
- `src/themes/*.ts`: `env` color entry in all 6 themes (3 variants each)
- `src/segments/renderer.ts`: `EnvSegmentConfig` interface + `renderEnv()` method
- `src/segments/index.ts`: export
- `src/config/loader.ts`: config type
- `src/powerline.ts`: wiring (symbols, colors, dispatch)
- `test/segments.test.ts`: 5 unit tests
- `README.md`: segment documentation

## Not changed

- `src/config/defaults.ts`: env segment has no sensible default for `variable`, so it's opt-in only

## Future: multiple env segments

Currently limited to one `env` segment per line since segments are keyed by type in the config object. If you're open to supporting multiple env vars, two possible approaches:

**Option A: Array value** (least disruptive)

```json
"env": [
  { "enabled": true, "variable": "CLAUDE_ACCOUNT", "prefix": "Acct" },
  { "enabled": true, "variable": "AWS_PROFILE", "prefix": "AWS" }
]
```

Config type becomes `env?: EnvSegmentConfig | EnvSegmentConfig[]`. The renderer checks if the value is an array and renders each entry as a separate segment. Backward-compatible (single object still works).

**Option B: Indexed keys**

```json
"env:account": { "enabled": true, "variable": "CLAUDE_ACCOUNT", "prefix": "Acct" },
"env:aws": { "enabled": true, "variable": "AWS_PROFILE", "prefix": "AWS" }
```

Segment dispatch strips the `:suffix` and matches on prefix. More expressive but requires changes to how segment types are resolved.

**Color consideration:** With multiple env segments, each instance currently shares the same theme color. A dynamic color strategy would be needed, either per-instance colors in the config (e.g. `"colorFrom": "model"`), cycling through a palette, or extending the theme to support an array of env colors. Happy to tackle this in a follow-up if there's interest.

## Screenshots
Third line shows first EnvSegment and then manual custom segment handled outside of powerline.
<img width="507" height="173" alt="image" src="https://github.com/user-attachments/assets/1a7795c6-22c2-42c4-a4b7-7256a32f5904" />
<img width="504" height="168" alt="image" src="https://github.com/user-attachments/assets/68cf844e-c41e-4f08-b246-5adb2f6bdf87" />
<img width="508" height="167" alt="image" src="https://github.com/user-attachments/assets/78400d9d-f3f0-4e34-a21c-3c285afaf7a8" />
<img width="510" height="177" alt="image" src="https://github.com/user-attachments/assets/5e9d5a45-0ce2-40e2-bbfe-a3c7c724687d" />
