### PR TITLE
feat(context): add blocks-line display style

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,12 +307,9 @@ Config files reload automatically and no restart needed.
 | `blocks-line` | █ | ─ | `█████───── 50%` |
 | `capped` | ━ | ┄ | `━━━━╸┄┄┄┄┄ 50%` |
 | `dots` | ● | ○ | `●●●●●○○○○○ 50%` |
-| `emoji` | 🟩 | ⬛ | `🟩🟩🟩🟩🟩⬛⬛⬛⬛⬛ 50%` |
 | `filled` | ■ | □ | `■■■■■□□□□□ 50%` |
 | `geometric` | ▰ | ▱ | `▰▰▰▰▰▱▱▱▱▱ 50%` |
 | `line` | ━ | ┄ | `━━━━━┄┄┄┄┄ 50%` |
-| `mono` | ⬜ | ─ | `⬜⬜⬜⬜⬜───── 50%` |
-| `mono-dot` | ⬜ | • | `⬜⬜⬜⬜⬜••••• 50%` |
 | `squares` | ◼ | ◻ | `◼◼◼◼◼◻◻◻◻◻ 50%` |
 
 **Symbols:** `◔` Context (unicode) • `C` Context (text)

--- a/src/segments/renderer.ts
+++ b/src/segments/renderer.ts
@@ -35,7 +35,7 @@ export interface TmuxSegmentConfig extends SegmentConfig {}
 
 export interface ContextSegmentConfig extends SegmentConfig {
   showPercentageOnly?: boolean;
-  displayStyle?: "text" | "ball" | "bar" | "blocks" | "blocks-line" | "capped" | "dots" | "emoji" | "filled" | "geometric" | "line" | "mono" | "mono-dot" | "squares";
+  displayStyle?: "text" | "ball" | "bar" | "blocks" | "blocks-line" | "capped" | "dots" | "filled" | "geometric" | "line" | "squares";
 }
 
 export interface MetricsSegmentConfig extends SegmentConfig {
@@ -138,12 +138,9 @@ const BAR_STYLES: Record<string, BarStyleDef> = {
   "blocks-line": { filled: "█", empty: "─" },
   capped:        { filled: "━", empty: "┄", cap: "╸" },
   dots:          { filled: "●", empty: "○" },
-  emoji:         { filled: "🟩", empty: "⬛" },
   filled:        { filled: "■", empty: "□" },
   geometric:     { filled: "▰", empty: "▱" },
   line:          { filled: "━", empty: "┄" },
-  mono:          { filled: "⬜", empty: "─" },
-  "mono-dot":    { filled: "⬜", empty: "•" },
   squares:       { filled: "◼", empty: "◻" },
 };
 


### PR DESCRIPTION
Sorry for reopening this.
The previous PR #58 included styles with emojis and special characters that weren't a good fit. 
This one keeps only `blocks-line`.  I'm using this style more than the ones I did add previously.

## Summary
- Add `blocks-line` display style for the context segment, a simple style that doesn't use emojis and takes the same space as existing styles

| Style | Filled | Empty | Example |
|-------|--------|-------|---------|
| `blocks-line` | █ | ─ | `█████─────` |

<img width="842" height="76" alt="Screenshot 2026-02-26 at 18 23 35" src="https://github.com/user-attachments/assets/789cd915-aed8-4bf5-aa24-ee264dc30f5e" />