### PR TITLE
fix(context): use autocompact buffer for usable context calculation

### DIFF
--- a/src/segments/context.ts
+++ b/src/segments/context.ts
@@ -60,7 +60,8 @@ export class ContextProvider {
       Math.max(0, Math.round((totalTokens / contextLimit) * 100))
     );
 
-    const usableLimit = Math.round(contextLimit * 0.75);
+    const autocompactBuffer = 33000;
+    const usableLimit = Math.max(1, contextLimit - autocompactBuffer);
     const usablePercentage = Math.min(
       100,
       Math.max(0, Math.round((totalTokens / usableLimit) * 100))


### PR DESCRIPTION
## Summary
- Replaced the hardcoded `contextLimit * 0.75` factor with `contextLimit - 33000` (the actual autocompact buffer size) when computing `usablePercentage`
- This aligns the statusline percentage with Claude Code's own `/context` reporting (e.g. 37% vs 31% previously shown as 41% vs 31%)

## Test plan
- [x] All 101 existing tests pass
- [x] Build succeeds
- [x] Verify statusline percentage now closely tracks `/context` output during a session -> see screenshot below

<img width="2240" height="316" alt="CleanShot 2026-03-02 at 20 03 14@2x" src="https://github.com/user-attachments/assets/8343e41b-6412-4416-a03d-1a4601f8d057" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)