### PR TITLE
fix: rename git.info to git.headVal

### DIFF
--- a/plugin/templates/config-tui-compact.json
+++ b/plugin/templates/config-tui-compact.json
@@ -18,7 +18,7 @@
         {
           "minWidth": 0,
           "areas": [
-            "git.icon   git.head     .            git.working",
+            "git.icon   git.headVal   .            git.working",
             "---",
             "context.icon  context.bar  context.pct  context.tokens"
           ],

--- a/plugin/templates/config-tui-full.json
+++ b/plugin/templates/config-tui-full.json
@@ -19,7 +19,7 @@
         "right": "{metrics.lastResponse}"
       },
       "segments": {
-        "git.info": {
+        "git.headVal": {
           "items": ["{branch}", "{status}", "{ahead}", "{behind}"],
           "gap": 1
         }
@@ -28,7 +28,7 @@
         {
           "minWidth": 55,
           "areas": [
-            "git.icon     git.info     git.info     git.info        git.working",
+            "git.icon     git.headVal     git.headVal     git.headVal        git.working",
             "---",
             "context.icon  context.bar  context.bar  context.pct     context.tokens",
             "block.icon    block.bar    block.bar    block.value     block.time",

--- a/plugin/templates/config-tui-standard.json
+++ b/plugin/templates/config-tui-standard.json
@@ -15,7 +15,7 @@
         "right": "{dir}"
       },
       "segments": {
-        "git.info": {
+        "git.headVal": {
           "items": ["{branch}", "{status}", "{ahead}", "{behind}"],
           "gap": 1
         }
@@ -24,7 +24,7 @@
         {
           "minWidth": 0,
           "areas": [
-            "git.icon     git.info     git.info     git.info     git.working",
+            "git.icon     git.headVal     git.headVal     git.headVal     git.working",
             "---",
             "context.icon  context.bar  context.bar  context.pct  context.tokens",
             "block.icon    block.bar    block.bar    block.value  block.time"

--- a/src/tui/sections.ts
+++ b/src/tui/sections.ts
@@ -659,7 +659,7 @@ function formatGitParts(data: TuiData, sym: SymbolSet): Record<string, string> {
   if (!data.gitInfo)
     return {
       icon: "",
-      info: "",
+      headVal: "",
       branch: "",
       status: "",
       ahead: "",
@@ -701,7 +701,7 @@ function formatGitParts(data: TuiData, sym: SymbolSet): Record<string, string> {
 
   return {
     icon: sym.branch,
-    info: infoParts.join(" "),
+    headVal: infoParts.join(" "),
     branch: data.gitInfo.branch,
     status: statusIcon,
     ahead,

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -66,7 +66,7 @@ export const SEGMENT_PARTS: Record<SegmentName, readonly string[]> = {
   weekly: ["icon", "label", "pct", "time", "bar"],
   git: [
     "icon",
-    "info",
+    "headVal",
     "branch",
     "status",
     "ahead",


### PR DESCRIPTION
## Summary
- Renames `git.info` segment part to `git.headVal` for naming consistency
- `git.head` = compound part with icon baked in (`⎇ branch status ahead behind`)
- `git.headVal` = icon-free version (`branch status ahead behind`)
- Aligns with the metrics naming pattern (`response`/`responseVal`, `added`/`addedVal`)
- Updates all TUI template presets (compact, standard, full)
- Fixes `config-tui-compact` which had `git.icon + git.head` (duplicate icon)