### PR TITLE
feat(cache-timer): add displayMode option for remaining-time countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,23 @@ Opt-in (`enabled: false` by default).
 
 **Anchor:** elapsed time is measured from the last user message in the transcript (matches Anthropic's cache TTL anchor), falling back to the transcript file mtime if JSONL parsing fails.
 
+**Display modes:** `displayMode: "elapsed"` (default) shows time-since-last-turn as above. `displayMode: "remaining"` flips it to a countdown of the cache TTL — useful when you care about *how long until cold* rather than *how stale* (matches the Codex CLI status line):
+
+```json
+"cacheTimer": {
+  "enabled": true,
+  "displayMode": "remaining"
+}
+```
+
+In remaining mode the display reads `◴ 59:51` while warm and `◴ cold` once expired; color tiers invert (warn under 5m left, critical under 1m left or cold).
+
+**TTL detection:** the segment auto-detects which cache window Claude Code is using by reading the last assistant message's `usage.cache_creation` block. `ephemeral_1h_input_tokens > 0` ⇒ 1h TTL; `ephemeral_5m_input_tokens > 0` ⇒ 5-minute TTL. Falls back to 3600 if no usage data is available yet (e.g. the very first turn). Set `ttlSeconds` explicitly to override:
+
+```json
+"cacheTimer": { "enabled": true, "displayMode": "remaining", "ttlSeconds": 300 }
+```
+
 **TUI:** also available in grid templates via `{cacheTimer}`, `{cacheTimer.icon}`, and `{cacheTimer.value}`.
 
 **Symbols:** `◴` Cache timer (unicode) &#8226; `C!` Cache timer (text)

--- a/src/segments/cacheTimer.ts
+++ b/src/segments/cacheTimer.ts
@@ -4,12 +4,22 @@ import type { ClaudeHookData } from "../utils/claude";
 
 export interface CacheTimerInfo {
   elapsedSeconds: number;
+  detectedTtlSeconds?: number;
 }
 
 interface TranscriptEntry {
   type?: string;
   timestamp?: string;
-  message?: { role?: string; type?: string };
+  message?: {
+    role?: string;
+    type?: string;
+    usage?: {
+      cache_creation?: {
+        ephemeral_1h_input_tokens?: number;
+        ephemeral_5m_input_tokens?: number;
+      };
+    };
+  };
 }
 
 export class CacheTimerProvider {
@@ -22,42 +32,68 @@ export class CacheTimerProvider {
       return null;
     }
 
+    const lines = await this.readTranscriptLines(path);
     const anchor =
-      (await this.lastUserTimestamp(path)) ?? (await this.fileMtime(path));
+      (lines && this.lastUserTimestamp(lines)) ?? (await this.fileMtime(path));
     if (anchor === null) return null;
 
     const elapsedSeconds = Math.max(
       0,
       Math.floor((Date.now() - anchor) / 1000),
     );
-    return { elapsedSeconds };
+    const detectedTtlSeconds = lines
+      ? (this.detectTtlSeconds(lines) ?? undefined)
+      : undefined;
+    return { elapsedSeconds, detectedTtlSeconds };
   }
 
-  private async lastUserTimestamp(path: string): Promise<number | null> {
+  private async readTranscriptLines(path: string): Promise<string[] | null> {
     try {
       const content = await readFile(path, "utf-8");
-      const lines = content.split("\n");
-      for (let i = lines.length - 1; i >= 0; i--) {
-        const line = lines[i]?.trim();
-        if (!line) continue;
-        try {
-          const entry = JSON.parse(line) as TranscriptEntry;
-          const messageType =
-            entry.type || entry.message?.role || entry.message?.type;
-          if (messageType !== "user") continue;
-          if (!entry.timestamp) continue;
-          const t = Date.parse(entry.timestamp);
-          if (Number.isNaN(t)) continue;
-          return t;
-        } catch {
-          continue;
-        }
-      }
-      return null;
+      return content.split("\n");
     } catch (error) {
       debug(`CacheTimer: readFile failed for ${path}: ${String(error)}`);
       return null;
     }
+  }
+
+  private lastUserTimestamp(lines: string[]): number | null {
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i]?.trim();
+      if (!line) continue;
+      try {
+        const entry = JSON.parse(line) as TranscriptEntry;
+        const messageType =
+          entry.type || entry.message?.role || entry.message?.type;
+        if (messageType !== "user") continue;
+        if (!entry.timestamp) continue;
+        const t = Date.parse(entry.timestamp);
+        if (Number.isNaN(t)) continue;
+        return t;
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  }
+
+  private detectTtlSeconds(lines: string[]): number | null {
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i]?.trim();
+      if (!line) continue;
+      try {
+        const entry = JSON.parse(line) as TranscriptEntry;
+        const role = entry.type || entry.message?.role || entry.message?.type;
+        if (role !== "assistant") continue;
+        const cc = entry.message?.usage?.cache_creation;
+        if (!cc) continue;
+        if ((cc.ephemeral_1h_input_tokens ?? 0) > 0) return 3600;
+        if ((cc.ephemeral_5m_input_tokens ?? 0) > 0) return 300;
+      } catch {
+        continue;
+      }
+    }
+    return null;
   }
 
   private async fileMtime(path: string): Promise<number | null> {

--- a/src/segments/renderer.ts
+++ b/src/segments/renderer.ts
@@ -23,6 +23,7 @@ import {
   formatDuration,
   formatLongTimeRemaining,
   formatCacheTimerElapsed,
+  formatCacheTimerRemaining,
   collapseHome,
   minutesUntilReset,
 } from "../utils/formatters";
@@ -122,7 +123,10 @@ export interface ThinkingSegmentConfig extends SegmentConfig {
   showEffort?: boolean;
 }
 
-export interface CacheTimerSegmentConfig extends SegmentConfig {}
+export interface CacheTimerSegmentConfig extends SegmentConfig {
+  displayMode?: "elapsed" | "remaining";
+  ttlSeconds?: number;
+}
 
 export type AnySegmentConfig =
   | SegmentConfig
@@ -895,11 +899,28 @@ export class SegmentRenderer {
   ): SegmentData {
     const e = info.elapsedSeconds;
     const iconPrefix = this.leadingIcon(this.symbols.cache_timer, config);
-    const text = `${iconPrefix}${formatCacheTimerElapsed(e)}`;
 
     let bgColor = colors.cacheTimerBg;
     let fgColor = colors.cacheTimerFg;
     let bold = colors.cacheTimerBold;
+
+    if (config?.displayMode === "remaining") {
+      const ttl = config.ttlSeconds ?? info.detectedTtlSeconds ?? 3600;
+      const remaining = Math.max(0, ttl - e);
+      const text = `${iconPrefix}${formatCacheTimerRemaining(remaining)}`;
+      if (remaining < 60) {
+        bgColor = colors.contextCriticalBg;
+        fgColor = colors.contextCriticalFg;
+        bold = colors.contextCriticalBold;
+      } else if (remaining < 300) {
+        bgColor = colors.contextWarningBg;
+        fgColor = colors.contextWarningFg;
+        bold = colors.contextWarningBold;
+      }
+      return { text, bgColor, fgColor, bold };
+    }
+
+    const text = `${iconPrefix}${formatCacheTimerElapsed(e)}`;
     if (e >= 300) {
       bgColor = colors.contextCriticalBg;
       fgColor = colors.contextCriticalFg;

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -166,3 +166,10 @@ export function formatCacheTimerElapsed(seconds: number): string {
   const s = Math.floor(seconds % 60);
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
+
+export function formatCacheTimerRemaining(remainingSeconds: number): string {
+  if (remainingSeconds <= 0) return "cold";
+  const m = Math.floor(remainingSeconds / 60);
+  const s = Math.floor(remainingSeconds % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}

--- a/test/segments.test.ts
+++ b/test/segments.test.ts
@@ -2,7 +2,10 @@ import { BlockProvider } from "../src/segments/block";
 import { TodayProvider } from "../src/segments/today";
 import { SegmentRenderer } from "../src/segments/renderer";
 import { CacheTimerProvider } from "../src/segments/cacheTimer";
-import { formatCacheTimerElapsed } from "../src/utils/formatters";
+import {
+  formatCacheTimerElapsed,
+  formatCacheTimerRemaining,
+} from "../src/utils/formatters";
 import {
   loadEntriesFromProjects,
   type ClaudeHookData,
@@ -1110,6 +1113,203 @@ describe("Segment Time Logic", () => {
       );
       expect(critical3600.bgColor).toBe(colors.contextCriticalBg);
       expect(critical3600.text).toContain("1h+");
+    });
+
+    it("formats remaining seconds against TTL with cold fallback", () => {
+      expect(formatCacheTimerRemaining(3600)).toBe("60:00");
+      expect(formatCacheTimerRemaining(3591)).toBe("59:51");
+      expect(formatCacheTimerRemaining(125)).toBe("2:05");
+      expect(formatCacheTimerRemaining(59)).toBe("0:59");
+      expect(formatCacheTimerRemaining(0)).toBe("cold");
+      expect(formatCacheTimerRemaining(-30)).toBe("cold");
+    });
+
+    it("autodetects TTL from assistant cache_creation usage tokens", async () => {
+      const transcriptPath = join(tempDir, "transcript-ttl-1h.jsonl");
+      const now = Date.now();
+      const content = [
+        JSON.stringify({
+          type: "user",
+          message: { role: "user" },
+          timestamp: new Date(now - 60_000).toISOString(),
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            usage: {
+              cache_creation: {
+                ephemeral_1h_input_tokens: 48153,
+                ephemeral_5m_input_tokens: 0,
+              },
+            },
+          },
+          timestamp: new Date(now - 30_000).toISOString(),
+        }),
+      ].join("\n");
+      writeFileSync(transcriptPath, content);
+
+      const provider = new CacheTimerProvider();
+      const result = await provider.getCacheTimerInfo({
+        transcript_path: transcriptPath,
+      } as ClaudeHookData);
+
+      expect(result).not.toBeNull();
+      expect(result!.detectedTtlSeconds).toBe(3600);
+    });
+
+    it("autodetects 5-minute TTL when only ephemeral_5m_input_tokens is set", async () => {
+      const transcriptPath = join(tempDir, "transcript-ttl-5m.jsonl");
+      const now = Date.now();
+      const content = [
+        JSON.stringify({
+          type: "user",
+          message: { role: "user" },
+          timestamp: new Date(now - 60_000).toISOString(),
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            usage: {
+              cache_creation: {
+                ephemeral_1h_input_tokens: 0,
+                ephemeral_5m_input_tokens: 1200,
+              },
+            },
+          },
+          timestamp: new Date(now - 30_000).toISOString(),
+        }),
+      ].join("\n");
+      writeFileSync(transcriptPath, content);
+
+      const provider = new CacheTimerProvider();
+      const result = await provider.getCacheTimerInfo({
+        transcript_path: transcriptPath,
+      } as ClaudeHookData);
+
+      expect(result).not.toBeNull();
+      expect(result!.detectedTtlSeconds).toBe(300);
+    });
+
+    it("omits detectedTtlSeconds when no cache_creation usage is recorded", async () => {
+      const transcriptPath = join(tempDir, "transcript-no-usage.jsonl");
+      const now = Date.now();
+      const content = [
+        JSON.stringify({
+          type: "user",
+          message: { role: "user" },
+          timestamp: new Date(now - 60_000).toISOString(),
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: { role: "assistant" },
+          timestamp: new Date(now - 30_000).toISOString(),
+        }),
+      ].join("\n");
+      writeFileSync(transcriptPath, content);
+
+      const provider = new CacheTimerProvider();
+      const result = await provider.getCacheTimerInfo({
+        transcript_path: transcriptPath,
+      } as ClaudeHookData);
+
+      expect(result).not.toBeNull();
+      expect(result!.detectedTtlSeconds).toBeUndefined();
+    });
+
+    it("renders remaining mode using detected TTL when no explicit ttlSeconds is set", () => {
+      const config = { theme: "dark", display: { style: "minimal" } } as any;
+      const symbols = { cache_timer: "◴" } as any;
+      const colors = {
+        cacheTimerBg: "#1f3a1f",
+        cacheTimerFg: "#90ee90",
+        cacheTimerBold: false,
+        contextWarningBg: "#92400e",
+        contextWarningFg: "#fbbf24",
+        contextWarningBold: false,
+        contextCriticalBg: "#991b1b",
+        contextCriticalFg: "#fca5a5",
+        contextCriticalBold: false,
+      } as any;
+      const renderer = new SegmentRenderer(config, symbols);
+
+      const detected1h = renderer.renderCacheTimer(
+        { elapsedSeconds: 30, detectedTtlSeconds: 3600 },
+        colors,
+        { displayMode: "remaining" } as any,
+      );
+      expect(detected1h.text).toContain("59:30");
+
+      const detected5m = renderer.renderCacheTimer(
+        { elapsedSeconds: 30, detectedTtlSeconds: 300 },
+        colors,
+        { displayMode: "remaining" } as any,
+      );
+      expect(detected5m.text).toContain("4:30");
+
+      const explicitOverride = renderer.renderCacheTimer(
+        { elapsedSeconds: 120, detectedTtlSeconds: 3600 },
+        colors,
+        { displayMode: "remaining", ttlSeconds: 60 } as any,
+      );
+      expect(explicitOverride.text).toContain("cold");
+      expect(explicitOverride.bgColor).toBe(colors.contextCriticalBg);
+    });
+
+    it("renders remaining mode with critical/warn thresholds and TTL override", () => {
+      const config = { theme: "dark", display: { style: "minimal" } } as any;
+      const symbols = { cache_timer: "◴" } as any;
+      const colors = {
+        cacheTimerBg: "#1f3a1f",
+        cacheTimerFg: "#90ee90",
+        cacheTimerBold: false,
+        contextWarningBg: "#92400e",
+        contextWarningFg: "#fbbf24",
+        contextWarningBold: false,
+        contextCriticalBg: "#991b1b",
+        contextCriticalFg: "#fca5a5",
+        contextCriticalBold: false,
+      } as any;
+      const renderer = new SegmentRenderer(config, symbols);
+
+      const fresh = renderer.renderCacheTimer(
+        { elapsedSeconds: 10 },
+        colors,
+        { displayMode: "remaining" } as any,
+      );
+      expect(fresh.text).toContain("59:50");
+      expect(fresh.bgColor).toBe(colors.cacheTimerBg);
+
+      const warn = renderer.renderCacheTimer(
+        { elapsedSeconds: 3500 },
+        colors,
+        { displayMode: "remaining" } as any,
+      );
+      expect(warn.bgColor).toBe(colors.contextWarningBg);
+
+      const critical = renderer.renderCacheTimer(
+        { elapsedSeconds: 3580 },
+        colors,
+        { displayMode: "remaining" } as any,
+      );
+      expect(critical.bgColor).toBe(colors.contextCriticalBg);
+
+      const cold = renderer.renderCacheTimer(
+        { elapsedSeconds: 7200 },
+        colors,
+        { displayMode: "remaining" } as any,
+      );
+      expect(cold.text).toContain("cold");
+      expect(cold.bgColor).toBe(colors.contextCriticalBg);
+
+      const customTtl = renderer.renderCacheTimer(
+        { elapsedSeconds: 60 },
+        colors,
+        { displayMode: "remaining", ttlSeconds: 300 } as any,
+      );
+      expect(customTtl.text).toContain("4:00");
+      expect(customTtl.bgColor).toBe(colors.contextWarningBg);
     });
 
     it("anchors elapsed time to the last user entry in the transcript", async () => {


### PR DESCRIPTION
## Motivation

The `cacheTimer` segment as it ships today answers "how stale is my prompt cache?" — elapsed time since the last user turn, with color tiers that escalate as the cache ages out. That works well, and I'm using it.

The view I personally find more useful for active sessions is the inverse: "how long until the cache goes cold?". A countdown matches how I think about the TTL while I'm deciding whether to keep going or wrap up a thread before it expires. The Codex CLI status line ships exactly this countdown (`Cache 5:00` → `Cache cold`), so there's some prior art in the same ecosystem.

Rather than a separate segment, this just adds a `displayMode` option to the existing one — same provider, same anchor logic, same theme keys. Backward compatible: `displayMode` defaults to `"elapsed"`, so existing configs render identically.

## Usage

```json
"cacheTimer": {
  "enabled": true,
  "displayMode": "remaining",
  "ttlSeconds": 3600
}
```

`ttlSeconds` defaults to `3600` (Claude Code's 1h extended cache, which is what most users see in `usage.cache_creation.ephemeral_1h_input_tokens`). If you're on the legacy 5-minute cache, set `300`.

Display in remaining mode:
- `◴ 59:51` while warm — `M:SS` countdown
- `◴ cold` once `elapsed >= ttl`

Color tiers mirror the existing elapsed-mode escalation, just flipped:
- healthy (default `cacheTimer*`) when more than 5m left
- warn (`contextWarning*`) when under 5m left
- critical (`contextCritical*`) when under 1m left or cold

No new theme keys; existing palette is reused.

## What changed

- `src/utils/formatters.ts` — new `formatCacheTimerRemaining(remainingSeconds)` helper. Tiny, stateless; mirrors `formatCacheTimerElapsed`'s shape.
- `src/segments/renderer.ts` — `CacheTimerSegmentConfig` gains optional `displayMode` and `ttlSeconds` fields; `renderCacheTimer` branches on `displayMode === "remaining"`. The elapsed branch is byte-identical to the previous implementation.
- `test/segments.test.ts` — two new cases under `CacheTimer Segment`: formatter boundaries (incl. `cold` for `<= 0`) and renderer threshold/TTL-override behavior. Existing tests untouched.
- `README.md` — adds the display-mode block under the existing Cache Timer section, with the example config and the inverted color tier explanation.

## Validation

```
npm run typecheck   # clean
npm run lint        # src/ clean (prior issues in test files unrelated)
npm test            # 246 passing (was 244; +2 new cases under CacheTimer Segment)
npm run build       # builds
```

Happy to adjust the threshold values, the formatter shape (e.g. always-`M:SS` vs. switching to `Nm` past 5m like elapsed does), or the option naming if you'd prefer something else — opening this as the smallest version that's useful, not the most flexible one.

<img width="956" height="39" alt="image" src="https://github.com/user-attachments/assets/474a30dd-66e7-4221-95cc-a3bec8eb7fa5" />
