### PR TITLE
feat(segments): add showUnits option to session/today tokens display

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ In `--worktree` sessions, the directory segment automatically shows the original
 
 - `type`: Display format - `cost` | `tokens` | `both` | `breakdown`
 - `costSource`: Cost calculation method - `calculated` (ccusage-style) | `official` (hook data)
+- `showUnits`: Show the trailing `tokens` unit when `type` is `tokens` or `both` (default: `true`). Set to `false` to render `§ 4.4M` instead of `§ 4.4M tokens`. Only applies to the powerline/capsule/minimal styles; the `tui` style already renders tokens without a suffix
 
 **Symbols:** `§` Session (unicode) &#8226; `S` Session (text)
 
@@ -218,13 +219,14 @@ In `--worktree` sessions, the directory segment automatically shows the original
 ```json
 "today": {
   "enabled": true,
-  "type": "cost"
+  "type": "both"
 }
 ```
 
 **Options:**
 
 - `type`: Display format - `cost` | `tokens` | `both` | `breakdown`
+- `showUnits`: Show the trailing `tokens` unit when `type` is `tokens` or `both` (default: `true`). Set to `false` to render `☉ $12.34 (4.4M)` instead of `☉ $12.34 (4.4M tokens)`. Only applies to the powerline/capsule/minimal styles; the `tui` style already renders tokens without a suffix
 
 **Symbols:** `☉` Today (unicode) &#8226; `D` Today (text)
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -27,8 +27,13 @@ export const DEFAULT_CONFIG: PowerlineConfig = {
             showRepoName: false,
           },
           model: { enabled: true },
-          session: { enabled: true, type: "tokens", costSource: "calculated" },
-          today: { enabled: true, type: "cost" },
+          session: {
+            enabled: true,
+            type: "tokens",
+            costSource: "calculated",
+            showUnits: true,
+          },
+          today: { enabled: true, type: "cost", showUnits: true },
           block: {
             enabled: false,
             type: "cost",

--- a/src/segments/renderer.ts
+++ b/src/segments/renderer.ts
@@ -18,6 +18,7 @@ import {
   abbreviateFishStyle,
   formatCost,
   formatTokens,
+  formatTokenCount,
   formatTokenBreakdown,
   formatTimeSince,
   formatDuration,
@@ -55,6 +56,8 @@ export interface GitSegmentConfig extends SegmentConfig {
 export interface UsageSegmentConfig extends SegmentConfig {
   type: "cost" | "tokens" | "both" | "breakdown";
   costSource?: "calculated" | "official";
+  /** Show the trailing "tokens" unit on token counts. Only affects `type: "tokens"` and `type: "both"` (default: true). Inert in the `tui` display style, which never renders the suffix. */
+  showUnits?: boolean;
 }
 
 export interface TmuxSegmentConfig extends SegmentConfig {}
@@ -96,6 +99,8 @@ export interface BlockSegmentConfig extends SegmentConfig {
 
 export interface TodaySegmentConfig extends SegmentConfig {
   type: "cost" | "tokens" | "both" | "breakdown";
+  /** Show the trailing "tokens" unit on token counts. Only affects `type: "tokens"` and `type: "both"` (default: true). Inert in the `tui` display style, which never renders the suffix. */
+  showUnits?: boolean;
 }
 
 export interface VersionSegmentConfig extends SegmentConfig {}
@@ -393,6 +398,7 @@ export class SegmentRenderer {
       usageInfo.session.tokenBreakdown,
       type,
       sessionBudget,
+      config?.showUnits ?? true,
     );
 
     if (formattedUsage === null) return null;
@@ -740,6 +746,7 @@ export class SegmentRenderer {
       todayInfo.tokenBreakdown,
       type,
       todayBudget,
+      config?.showUnits ?? true,
     );
 
     if (formattedUsage === null) return null;
@@ -776,14 +783,18 @@ export class SegmentRenderer {
     tokens: number | null,
     tokenBreakdown: TokenBreakdown | null,
     type: string,
+    showUnits: boolean,
   ): string {
+    const tokenStr = showUnits
+      ? formatTokens(tokens)
+      : formatTokenCount(tokens);
     switch (type) {
       case "cost":
         return formatCost(cost);
       case "tokens":
-        return formatTokens(tokens);
+        return tokenStr;
       case "both":
-        return `${formatCost(cost)} (${formatTokens(tokens)})`;
+        return `${formatCost(cost)} (${tokenStr})`;
       case "breakdown":
         return formatTokenBreakdown(tokenBreakdown);
       default:
@@ -796,7 +807,8 @@ export class SegmentRenderer {
     tokens: number | null,
     tokenBreakdown: TokenBreakdown | null,
     type: string,
-    budget?: BudgetItemConfig,
+    budget: BudgetItemConfig | undefined,
+    showUnits: boolean,
   ): string | null {
     const state = resolveBudgetDisplay(cost, tokens, budget);
     if (state.suppressAll) return null;
@@ -807,6 +819,7 @@ export class SegmentRenderer {
       tokens,
       tokenBreakdown,
       type,
+      showUnits,
     );
     return state.percentText
       ? `${baseDisplay} ${state.percentText}`

--- a/test/segments.test.ts
+++ b/test/segments.test.ts
@@ -1327,4 +1327,155 @@ describe("Segment Time Logic", () => {
       ).toBeNull();
     });
   });
+
+  describe("Token unit toggle (session / today showUnits)", () => {
+    const sessionSymbols = { session_cost: "§" } as any;
+    const todaySymbols = { today_cost: "☉" } as any;
+    const sessionColors = {
+      sessionBg: "",
+      sessionFg: "",
+      sessionBold: false,
+    } as any;
+    const todayColors = {
+      todayBg: "",
+      todayFg: "",
+      todayBold: false,
+    } as any;
+    const baseConfig = {
+      theme: "dark",
+      display: { style: "minimal", showIcons: false, lines: [] },
+    } as any;
+
+    function renderSessionWith(type: string, showUnits?: boolean) {
+      const renderer = new SegmentRenderer(baseConfig, sessionSymbols);
+      const usageInfo = {
+        session: {
+          cost: 12.34,
+          tokens: 4_400_000,
+          calculatedCost: 12.34,
+          officialCost: null,
+          tokenBreakdown: null,
+        },
+      } as any;
+      return renderer.renderSession(usageInfo, sessionColors, {
+        enabled: true,
+        type,
+        showUnits,
+      } as any);
+    }
+
+    function renderTodayWith(type: string, showUnits?: boolean) {
+      const renderer = new SegmentRenderer(baseConfig, todaySymbols);
+      const todayInfo = {
+        cost: 12.34,
+        tokens: 4_400_000,
+        tokenBreakdown: {
+          input: 1_000,
+          output: 2_000,
+          cacheCreation: 0,
+          cacheRead: 500,
+        },
+        date: "2026-04-24",
+      } as any;
+      return renderer.renderToday(todayInfo, todayColors, {
+        enabled: true,
+        type,
+        showUnits,
+      } as any);
+    }
+
+    it("session type:tokens keeps the ' tokens' suffix by default", () => {
+      expect(renderSessionWith("tokens", undefined)!.text).toBe("4.4M tokens");
+      expect(renderSessionWith("tokens", true)!.text).toBe("4.4M tokens");
+    });
+
+    it("session type:tokens drops the ' tokens' suffix when showUnits is false", () => {
+      expect(renderSessionWith("tokens", false)!.text).toBe("4.4M");
+    });
+
+    it("session type:both drops the suffix inside the parentheses when showUnits is false", () => {
+      expect(renderSessionWith("both", false)!.text).toBe("$12.34 (4.4M)");
+      expect(renderSessionWith("both", true)!.text).toBe(
+        "$12.34 (4.4M tokens)",
+      );
+    });
+
+    it("today type:tokens drops the ' tokens' suffix when showUnits is false", () => {
+      expect(renderTodayWith("tokens", false)!.text).toBe("4.4M");
+      expect(renderTodayWith("tokens", true)!.text).toBe("4.4M tokens");
+    });
+
+    it("today type:both drops the suffix inside the parentheses when showUnits is false", () => {
+      expect(renderTodayWith("both", false)!.text).toBe("$12.34 (4.4M)");
+      expect(renderTodayWith("both", true)!.text).toBe("$12.34 (4.4M tokens)");
+    });
+
+    it("today type:breakdown ignores showUnits (no 'tokens' suffix to drop)", () => {
+      const expected = "1.0K in + 2.0K out + 500 cached";
+      expect(renderTodayWith("breakdown", true)!.text).toBe(expected);
+      expect(renderTodayWith("breakdown", false)!.text).toBe(expected);
+    });
+
+    it("today type:cost is unaffected by showUnits", () => {
+      expect(renderTodayWith("cost", false)!.text).toBe("$12.34");
+      expect(renderTodayWith("cost", true)!.text).toBe("$12.34");
+    });
+
+    it("session type:tokens with zero tokens drops 'tokens' when showUnits is false", () => {
+      const renderer = new SegmentRenderer(baseConfig, sessionSymbols);
+      const usageInfo = {
+        session: {
+          cost: 0,
+          tokens: 0,
+          calculatedCost: 0,
+          officialCost: null,
+          tokenBreakdown: null,
+        },
+      } as any;
+      const cfg = (showUnits: boolean) => ({
+        enabled: true,
+        type: "tokens",
+        showUnits,
+      });
+      expect(
+        renderer.renderSession(usageInfo, sessionColors, cfg(false) as any)!
+          .text,
+      ).toBe("0");
+      expect(
+        renderer.renderSession(usageInfo, sessionColors, cfg(true) as any)!
+          .text,
+      ).toBe("0 tokens");
+    });
+
+    it("session type:tokens with a budget threads showUnits through to the formatted base", () => {
+      const configWithBudget = {
+        theme: "dark",
+        display: { style: "minimal", showIcons: false, lines: [] },
+        budget: { session: { amount: 50, warningThreshold: 80 } },
+      } as any;
+      const renderer = new SegmentRenderer(configWithBudget, sessionSymbols);
+      const usageInfo = {
+        session: {
+          cost: 10,
+          tokens: 4_400_000,
+          calculatedCost: 10,
+          officialCost: null,
+          tokenBreakdown: null,
+        },
+      } as any;
+      const cfg = (showUnits: boolean) => ({
+        enabled: true,
+        type: "tokens",
+        showUnits,
+      });
+      expect(
+        renderer.renderSession(usageInfo, sessionColors, cfg(false) as any)!
+          .text,
+      ).toBe("4.4M 20%");
+      expect(
+        renderer.renderSession(usageInfo, sessionColors, cfg(true) as any)!
+          .text,
+      ).toBe("4.4M tokens 20%");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #87.

Adds a `showUnits` boolean on the `session` and `today` segment configs that hides the trailing ` tokens` / `M tokens` / `K tokens` suffix when set to `false`. The `§` / `☉` icons already say what the number is, so on narrow status lines the suffix is just width spent on a redundant label.

## Behavior

```json
"session": { "type": "tokens", "showUnits": false }
"today":   { "type": "both",   "showUnits": false }
```

Renders:

```
§ 4.4M   ☉ $12.34 (4.4M)
```

Versus the current (and still default) rendering:

```
§ 4.4M tokens   ☉ $12.34 (4.4M tokens)
```

- Applies when `type` is `tokens` or `both`.
- No-op when `type` is `breakdown` (already renders without a `tokens` suffix via `formatTokenCount`).
- No-op when `type` is `cost`.
- Defaults to `true`, so existing configs are unchanged.
- Only affects the powerline/capsule/minimal display styles. The `tui` style already renders tokens without a suffix and is unchanged by this PR.

## Implementation notes

- New `showUnits?: boolean` field on `UsageSegmentConfig` and `TodaySegmentConfig` in `src/segments/renderer.ts`, with a JSDoc one-liner noting the `tokens` / `both` scope and the TUI no-op.
- `formatUsageDisplay` and `formatUsageWithBudget` pick between the existing `formatTokens` (with suffix) and `formatTokenCount` (without) helpers based on the flag. No change to the public `formatTokens` signature, which is re-exported from `src/browser.ts`.
- Default is resolved once, at the call sites in `renderSession` and `renderToday`, via `config?.showUnits ?? true`. This also covers a `"showUnits": null` written into JSON.
- `defaults.ts` carries the explicit `true` for discoverability, matching the existing `agent.showLabel` and `sessionId.showIdLabel` patterns.

## Test plan

- [x] 253/253 unit tests passing (`npm test`), including 9 new cases under "Token unit toggle (session / today showUnits)" in `test/segments.test.ts`. Coverage: default-on, opt-out for `tokens` and `both` on both segments, asserted exact breakdown string for the `breakdown` no-op, no-op for `cost`, the zero-tokens edge case, and a budget-path interaction (locks the `showUnits` threading through `formatUsageWithBudget`).
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run build` clean.
- [x] Manual smoke against the built binary:

  With `showUnits` omitted (default):
  ```
   § 0 tokens  ☉ $132.34 (184.3M tokens) !100%
  ```
  With `showUnits: false`:
  ```
   § 0  ☉ $132.26 (184.2M) !100%
  ```

## Follow-up (not part of this PR)

`src/utils/formatters.ts:120` defines `formatTokenCount` as `formatTokens(tokens).replace(" tokens", "")` — a string-strip that this PR now depends on. Worth a small refactor to extract a shared numeric formatter, but out of scope here. Happy to file as a follow-up issue if useful.
