### PR TITLE
Surface worktree indicator (⧉) without requiring showRepoName

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,12 @@ In `--worktree` sessions, the directory segment automatically shows the original
 - `showStashCount`: Show stash count
 - `showUpstream`: Show upstream branch
 - `showRepoName`: Show repository name
+- `showWorktree`: Show the worktree indicator (⧉) when the current directory belongs to a linked git worktree. Defaults to whatever `showRepoName` is, so set it explicitly to get the indicator on its own — or to `false` to suppress it while still showing the repo name
 
 **Symbols:**
 
-- Unicode: `⎇` Branch &#8226; `♯` SHA &#8226; `⌂` Tag &#8226; `⧇` Stash &#8226; `✓` Clean &#8226; `●` Dirty &#8226; `⚠` Conflicts &#8226; `↑3` Ahead &#8226; `↓2` Behind &#8226; `(+1 ~2 ?3)` Staged/Unstaged/Untracked
-- Text: `~` Branch &#8226; `#` SHA &#8226; `T` Tag &#8226; `S` Stash &#8226; `=` Clean &#8226; `*` Dirty &#8226; `!` Conflicts &#8226; `^3` Ahead &#8226; `v2` Behind &#8226; `(+1 ~2 ?3)` Staged/Unstaged/Untracked
+- Unicode: `⎇` Branch &#8226; `♯` SHA &#8226; `⌂` Tag &#8226; `⧇` Stash &#8226; `✓` Clean &#8226; `●` Dirty &#8226; `⚠` Conflicts &#8226; `↑3` Ahead &#8226; `↓2` Behind &#8226; `⧉` Worktree &#8226; `(+1 ~2 ?3)` Staged/Unstaged/Untracked
+- Text: `~` Branch &#8226; `#` SHA &#8226; `T` Tag &#8226; `S` Stash &#8226; `=` Clean &#8226; `*` Dirty &#8226; `!` Conflicts &#8226; `^3` Ahead &#8226; `v2` Behind &#8226; `W` Worktree &#8226; `(+1 ~2 ?3)` Staged/Unstaged/Untracked
 
 </details>
 

--- a/src/powerline.ts
+++ b/src/powerline.ts
@@ -43,6 +43,7 @@ import {
   TmuxService,
   MetricsProvider,
   SegmentRenderer,
+  shouldShowWorktree,
 } from "./segments";
 import { BlockProvider } from "./segments/block";
 import { TodayProvider } from "./segments/today";
@@ -319,6 +320,9 @@ export class PowerlineRenderer {
       .map((line) => line.segments.context)
       .find((c) => c?.enabled) as ContextSegmentConfig | undefined;
     const autocompactBuffer = contextSegmentConfig?.autocompactBuffer ?? 33000;
+    const gitSegmentConfig = this.config.display.lines
+      .map((line) => line.segments.git)
+      .find((g) => g?.enabled) as GitSegmentConfig | undefined;
 
     const results = await Promise.allSettled([
       this.usageProvider.getUsageInfo(hookData.session_id, hookData),
@@ -337,6 +341,7 @@ export class PowerlineRenderer {
           showStashCount: false,
           showUpstream: false,
           showRepoName: false,
+          showWorktree: shouldShowWorktree(gitSegmentConfig),
         },
         hookData.workspace?.project_dir,
       ),
@@ -647,6 +652,7 @@ export class PowerlineRenderer {
         showStashCount: config?.showStashCount,
         showUpstream: config?.showUpstream,
         showRepoName: config?.showRepoName,
+        showWorktree: shouldShowWorktree(config),
       },
       hookData.workspace?.project_dir,
     );

--- a/src/segments/git.ts
+++ b/src/segments/git.ts
@@ -69,15 +69,16 @@ export class GitService {
       showStashCount?: boolean;
       showUpstream?: boolean;
       showRepoName?: boolean;
+      showWorktree?: boolean;
     } = {},
     projectDir?: string,
   ): Promise<GitInfo | null> {
     let gitDir: string;
-    const isWorktreeDir = this.isWorktree(workingDir);
 
-    if (isWorktreeDir) {
-      // Worktree's .git is a file pointing to the main repo;
-      // git commands must run from the worktree directory.
+    if (this.hasGitFile(workingDir)) {
+      // A `.git` file rather than a directory means a linked worktree or a
+      // submodule; either way git commands must run from this directory
+      // instead of the project dir.
       gitDir = workingDir;
     } else if (projectDir && this.isGitRepo(projectDir)) {
       gitDir = projectDir;
@@ -137,6 +138,10 @@ export class GitService {
         lightOperations.repoName = this.getRepoNameAsync(gitDir);
       }
 
+      if (options.showWorktree) {
+        lightOperations.isWorktree = this.isLinkedWorktreeAsync(gitDir);
+      }
+
       const resultMap = new Map<string, unknown>();
 
       for (const [key, promise] of Object.entries(heavyOperations)) {
@@ -188,7 +193,10 @@ export class GitService {
 
       if (options.showRepoName) {
         result.repoName = (resultMap.get("repoName") as string) || undefined;
-        result.isWorktree = isWorktreeDir;
+      }
+
+      if (options.showWorktree) {
+        result.isWorktree = resultMap.get("isWorktree") === true;
       }
 
       return result;
@@ -336,13 +344,34 @@ export class GitService {
     }
   }
 
-  private isWorktree(workingDir: string): boolean {
+  private hasGitFile(workingDir: string): boolean {
     try {
-      const gitDir = path.join(workingDir, ".git");
-      if (fs.existsSync(gitDir) && fs.statSync(gitDir).isFile()) {
-        return true;
-      }
+      const gitPath = path.join(workingDir, ".git");
+      return fs.existsSync(gitPath) && fs.statSync(gitPath).isFile();
+    } catch {
       return false;
+    }
+  }
+
+  private async isLinkedWorktreeAsync(workingDir: string): Promise<boolean> {
+    try {
+      const result = await this.execGitAsync(
+        "git rev-parse --git-dir --git-common-dir",
+        {
+          cwd: workingDir,
+          encoding: "utf8",
+          timeout: 2000,
+        },
+      );
+      const [gitDir, commonDir] = result.stdout.trim().split("\n");
+      if (!gitDir || !commonDir) return false;
+
+      // A linked worktree has its own git dir under the main repo's
+      // .git/worktrees/, so the two paths differ. They are equal for a normal
+      // checkout, and for a submodule (whose .git is also a file).
+      return (
+        path.resolve(workingDir, gitDir) !== path.resolve(workingDir, commonDir)
+      );
     } catch {
       return false;
     }

--- a/src/segments/index.ts
+++ b/src/segments/index.ts
@@ -9,7 +9,7 @@ export { MetricsProvider } from "./metrics";
 export type { MetricsInfo } from "./metrics";
 export { CacheTimerProvider } from "./cacheTimer";
 export type { CacheTimerInfo } from "./cacheTimer";
-export { SegmentRenderer } from "./renderer";
+export { SegmentRenderer, shouldShowWorktree } from "./renderer";
 export type {
   PowerlineSymbols,
   AnySegmentConfig,

--- a/src/segments/renderer.ts
+++ b/src/segments/renderer.ts
@@ -52,6 +52,17 @@ export interface GitSegmentConfig extends SegmentConfig {
   showStashCount?: boolean;
   showUpstream?: boolean;
   showRepoName?: boolean;
+  /** Show the worktree indicator when in a linked worktree. Defaults to `showRepoName`, so setting it explicitly decouples the two. */
+  showWorktree?: boolean;
+}
+
+/**
+ * Resolves whether the worktree indicator is visible. Both the git service
+ * (to decide whether to detect it) and the renderers (to decide whether to
+ * draw it) go through here, so the two cannot drift apart.
+ */
+export function shouldShowWorktree(config?: GitSegmentConfig): boolean {
+  return config?.showWorktree ?? config?.showRepoName ?? false;
 }
 
 export interface UsageSegmentConfig extends SegmentConfig {
@@ -280,9 +291,12 @@ export class SegmentRenderer {
 
     if (config?.showRepoName && gitInfo.repoName) {
       parts.push(gitInfo.repoName);
-      if (gitInfo.isWorktree) {
-        parts.push(this.symbols.git_worktree);
-      }
+    }
+
+    // isWorktree is only populated when the caller asked for it via
+    // shouldShowWorktree, so there is nothing left to gate on here.
+    if (gitInfo.isWorktree) {
+      parts.push(this.symbols.git_worktree);
     }
 
     if (config?.showOperation && gitInfo.operation) {

--- a/src/tui/sections.ts
+++ b/src/tui/sections.ts
@@ -830,6 +830,7 @@ function formatGitParts(
       ahead: "",
       behind: "",
       working: "",
+      worktree: "",
       head: "",
     };
 
@@ -856,13 +857,18 @@ function formatGitParts(
     counts.push(`?${data.gitInfo.untracked}`);
   const working = counts.length > 0 ? `(${counts.join(" ")})` : "";
 
+  const worktree = data.gitInfo.isWorktree ? sym.git_worktree : "";
+
   const headParts: string[] = [];
+  if (worktree) headParts.push(worktree);
   if (iconVisible) headParts.push(sym.branch);
   headParts.push(data.gitInfo.branch, statusIcon);
   if (ahead) headParts.push(ahead);
   if (behind) headParts.push(behind);
 
-  const infoParts = [data.gitInfo.branch, statusIcon];
+  const infoParts: string[] = [];
+  if (worktree) infoParts.push(worktree);
+  infoParts.push(data.gitInfo.branch, statusIcon);
   if (ahead) infoParts.push(ahead);
   if (behind) infoParts.push(behind);
 
@@ -874,6 +880,7 @@ function formatGitParts(
     ahead,
     behind,
     working,
+    worktree,
     head: headParts.join(" "),
   };
 }
@@ -888,6 +895,7 @@ function formatGitSegment(
   let text = parts.icon
     ? `${parts.icon} ${parts.branch} ${parts.status}`
     : `${parts.branch} ${parts.status}`;
+  if (parts.worktree) text = `${parts.worktree} ${text}`;
   if (parts.ahead) text += ` ${parts.ahead}`;
   if (parts.behind) text += `${parts.behind}`;
   if (parts.working) text += ` ${parts.working}`;

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -1,7 +1,9 @@
 import { PowerlineRenderer } from "../src/powerline";
-import { SessionProvider } from "../src/segments";
+import { GitService, SessionProvider } from "../src/segments";
 import { loadConfigFromCLI } from "../src/config/loader";
+import type { PowerlineConfig } from "../src/config/loader";
 import { DEFAULT_CONFIG } from "../src/config/defaults";
+import { SYMBOLS } from "../src/utils/constants";
 import { writeFileSync, unlinkSync, mkdtempSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -117,11 +119,113 @@ describe("Core Functionality", () => {
     it("should override config with CLI args", () => {
       const config = loadConfigFromCLI(
         ["--theme=dark", "--style=powerline"],
-        tempDir
+        tempDir,
       );
 
       expect(config.theme).toBe("dark");
       expect(config.display.style).toBe("powerline");
+    });
+  });
+
+  describe("Worktree indicator wiring", () => {
+    let getGitInfo: jest.SpyInstance;
+
+    beforeEach(() => {
+      // Report a worktree only when the caller actually asked for detection,
+      // so these tests fail if the option stops reaching the git service.
+      getGitInfo = jest
+        .spyOn(GitService.prototype, "getGitInfo")
+        .mockImplementation(async (_workingDir, options) => ({
+          branch: "feature",
+          status: "clean" as const,
+          ahead: 0,
+          behind: 0,
+          isWorktree: options?.showWorktree === true,
+        }));
+    });
+
+    afterEach(() => {
+      getGitInfo.mockRestore();
+    });
+
+    const hookData = {
+      session_id: "worktree-session",
+      transcript_path: "/fake/path.jsonl",
+      model: { id: "claude-3-5-sonnet", display_name: "Claude" },
+      hook_event_name: "test",
+    };
+
+    const configWith = (
+      style: "minimal" | "tui",
+      git: Record<string, unknown>,
+    ): PowerlineConfig => ({
+      ...DEFAULT_CONFIG,
+      display: {
+        ...DEFAULT_CONFIG.display,
+        style,
+        lines: [
+          {
+            segments: {
+              ...DEFAULT_CONFIG.display.lines[0]!.segments,
+              git: { enabled: true, ...git },
+            },
+          },
+        ],
+      },
+    });
+
+    it.each(["minimal", "tui"] as const)(
+      "renders the indicator in the %s style when showWorktree is set",
+      async (style) => {
+        const result = await new PowerlineRenderer(
+          configWith(style, { showWorktree: true }),
+        ).generateStatusline({
+          ...hookData,
+          cwd: tempDir,
+          workspace: { project_dir: tempDir, current_dir: tempDir },
+        });
+
+        expect(result).toContain(SYMBOLS.git_worktree);
+      },
+    );
+
+    it.each(["minimal", "tui"] as const)(
+      "omits the indicator in the %s style by default",
+      async (style) => {
+        const result = await new PowerlineRenderer(
+          configWith(style, {}),
+        ).generateStatusline({
+          ...hookData,
+          cwd: tempDir,
+          workspace: { project_dir: tempDir, current_dir: tempDir },
+        });
+
+        expect(result).not.toContain(SYMBOLS.git_worktree);
+      },
+    );
+
+    it("inherits showRepoName when showWorktree is unset", async () => {
+      const result = await new PowerlineRenderer(
+        configWith("minimal", { showRepoName: true }),
+      ).generateStatusline({
+        ...hookData,
+        cwd: tempDir,
+        workspace: { project_dir: tempDir, current_dir: tempDir },
+      });
+
+      expect(result).toContain(SYMBOLS.git_worktree);
+    });
+
+    it("lets showWorktree: false suppress the indicator for repo-name users", async () => {
+      const result = await new PowerlineRenderer(
+        configWith("minimal", { showRepoName: true, showWorktree: false }),
+      ).generateStatusline({
+        ...hookData,
+        cwd: tempDir,
+        workspace: { project_dir: tempDir, current_dir: tempDir },
+      });
+
+      expect(result).not.toContain(SYMBOLS.git_worktree);
     });
   });
 
@@ -137,7 +241,9 @@ describe("Core Functionality", () => {
       const { ContextProvider } = require("../src/segments/context");
       const contextProvider = new ContextProvider(DEFAULT_CONFIG);
       const result =
-        await contextProvider.calculateContextTokensFromTranscript(transcriptPath);
+        await contextProvider.calculateContextTokensFromTranscript(
+          transcriptPath,
+        );
 
       expect(result).toBeDefined();
       expect(result.totalTokens).toBe(15000);
@@ -165,7 +271,7 @@ describe("Core Functionality", () => {
       const contextProvider = new ContextProvider(customConfig);
       const result = await contextProvider.calculateContextTokensFromTranscript(
         transcriptPath,
-        "claude-sonnet-4-20250514"
+        "claude-sonnet-4-20250514",
       );
 
       expect(result).toBeDefined();
@@ -194,7 +300,7 @@ describe("Core Functionality", () => {
       const contextProvider = new ContextProvider(customConfig);
       const result = await contextProvider.calculateContextTokensFromTranscript(
         transcriptPath,
-        "unknown-model"
+        "unknown-model",
       );
 
       expect(result).toBeDefined();
@@ -223,16 +329,18 @@ describe("Core Functionality", () => {
       const { ContextProvider } = require("../src/segments/context");
       const contextProvider = new ContextProvider(customConfig);
 
-      const sonnetResult = await contextProvider.calculateContextTokensFromTranscript(
-        transcriptPath,
-        "claude-3-5-sonnet-20241022"
-      );
+      const sonnetResult =
+        await contextProvider.calculateContextTokensFromTranscript(
+          transcriptPath,
+          "claude-3-5-sonnet-20241022",
+        );
       expect(sonnetResult?.maxTokens).toBe(500000);
 
-      const opusResult = await contextProvider.calculateContextTokensFromTranscript(
-        transcriptPath,
-        "claude-opus-4-20250514"
-      );
+      const opusResult =
+        await contextProvider.calculateContextTokensFromTranscript(
+          transcriptPath,
+          "claude-opus-4-20250514",
+        );
       expect(opusResult?.maxTokens).toBe(400000);
     });
   });

--- a/test/git-worktree.test.ts
+++ b/test/git-worktree.test.ts
@@ -4,25 +4,27 @@ import { join } from "node:path";
 import { GitService } from "../src/segments/git";
 
 jest.mock("node:child_process", () => ({
-  exec: jest.fn().mockImplementation((cmd: string, _options: any, callback: any) => {
-    let result = "";
-    if (cmd.includes("git status --porcelain -b")) result = "## main\n";
-    else if (cmd.includes("git rev-list --count")) result = "0\n";
-    else if (cmd.includes("git branch --show-current")) result = "main\n";
-
-    if (typeof callback === "function") {
-      callback(null, { stdout: result, stderr: "" });
-    }
-    return result;
-  }),
+  exec: jest.fn(),
 }));
 
-function createMockExec(branch: string): (cmd: string, _options: any, callback: any) => string {
+const WORKTREE_DIRS = "/repo/.git/worktrees/feature\n/repo/.git\n";
+const NORMAL_DIRS = "/repo/.git\n/repo/.git\n";
+const SUBMODULE_DIRS = "/repo/.git/modules/vendor\n/repo/.git/modules/vendor\n";
+
+function createMockExec(
+  branch: string,
+  revParseDirs: string,
+  topLevel = "",
+): (cmd: string, _options: any, callback: any) => string {
   return (cmd: string, _options: any, callback: any) => {
     let result = "";
     if (cmd.includes("git status --porcelain -b")) result = `## ${branch}\n`;
+    else if (cmd.includes("git rev-parse --show-toplevel"))
+      result = `${topLevel}\n`;
+    else if (cmd.includes("git rev-parse --git-dir")) result = revParseDirs;
     else if (cmd.includes("git rev-list --count")) result = "0\n";
-    else if (cmd.includes("git config --get remote.origin.url")) result = "git@github.com:user/repo.git\n";
+    else if (cmd.includes("git config --get remote.origin.url"))
+      result = "git@github.com:user/repo.git\n";
     else if (cmd.includes("git branch --show-current")) result = `${branch}\n`;
 
     if (typeof callback === "function") {
@@ -44,6 +46,7 @@ describe("GitService isWorktree", () => {
     gitService = new GitService();
 
     mockExec = jest.requireMock("node:child_process").exec;
+    mockExec.mockImplementation(createMockExec("main", NORMAL_DIRS));
   });
 
   afterEach(() => {
@@ -55,39 +58,96 @@ describe("GitService isWorktree", () => {
   });
 
   describe("worktree detection", () => {
-    it("should set isWorktree to true when .git is a file (worktree)", async () => {
-      writeFileSync(join(tempDir, ".git"), "gitdir: /some/path/.git/worktrees/test");
-      mockExec.mockImplementation(createMockExec("main"));
+    it("should set isWorktree to true when the git dir differs from the common dir", async () => {
+      writeFileSync(
+        join(tempDir, ".git"),
+        "gitdir: /repo/.git/worktrees/feature",
+      );
+      mockExec.mockImplementation(createMockExec("main", WORKTREE_DIRS));
 
-      const info = await gitService.getGitInfo(tempDir, { showRepoName: true });
+      const info = await gitService.getGitInfo(tempDir, { showWorktree: true });
 
       expect(info).not.toBeNull();
       expect(info!.isWorktree).toBe(true);
     });
 
-    it("should set isWorktree to false when .git is a directory (normal repo)", async () => {
+    it("should set isWorktree to false in a normal repo", async () => {
       mkdirSync(join(tempDir, ".git"), { recursive: true });
-      mockExec.mockImplementation(createMockExec("main"));
+      mockExec.mockImplementation(createMockExec("main", NORMAL_DIRS));
 
-      const info = await gitService.getGitInfo(tempDir, { showRepoName: true });
+      const info = await gitService.getGitInfo(tempDir, { showWorktree: true });
 
       expect(info).not.toBeNull();
       expect(info!.isWorktree).toBe(false);
     });
-  });
 
-  describe("gitDir resolution", () => {
-    it("should detect isWorktree based on workingDir, not gitDir from projectDir", async () => {
-      projectDir = mkdtempSync(join(tmpdir(), "powerline-project-test-"));
-      mkdirSync(join(projectDir, ".git"), { recursive: true });
+    it("should set isWorktree to false in a submodule, whose .git is also a file", async () => {
+      writeFileSync(join(tempDir, ".git"), "gitdir: /repo/.git/modules/vendor");
+      mockExec.mockImplementation(createMockExec("main", SUBMODULE_DIRS));
 
-      writeFileSync(join(tempDir, ".git"), "gitdir: /some/path/.git/worktrees/test");
-      mockExec.mockImplementation(createMockExec("feature-branch"));
+      const info = await gitService.getGitInfo(tempDir, { showWorktree: true });
 
-      const info = await gitService.getGitInfo(tempDir, { showRepoName: true }, projectDir);
+      expect(info).not.toBeNull();
+      expect(info!.isWorktree).toBe(false);
+    });
+
+    it("should detect a worktree from a subdirectory, which has no .git of its own", async () => {
+      const subDir = join(tempDir, "src", "nested");
+      mkdirSync(subDir, { recursive: true });
+      mockExec.mockImplementation(
+        createMockExec("main", WORKTREE_DIRS, tempDir),
+      );
+
+      const info = await gitService.getGitInfo(subDir, { showWorktree: true });
 
       expect(info).not.toBeNull();
       expect(info!.isWorktree).toBe(true);
+    });
+
+    it("should leave isWorktree undefined and skip the git call when not requested", async () => {
+      writeFileSync(
+        join(tempDir, ".git"),
+        "gitdir: /repo/.git/worktrees/feature",
+      );
+      mockExec.mockImplementation(createMockExec("main", WORKTREE_DIRS));
+
+      const info = await gitService.getGitInfo(tempDir, {});
+
+      expect(info).not.toBeNull();
+      expect(info!.isWorktree).toBeUndefined();
+      expect(
+        mockExec.mock.calls.filter(([cmd]) =>
+          String(cmd).includes("--git-common-dir"),
+        ),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe("gitDir resolution", () => {
+    it("should run git in the worktree, not in the project dir", async () => {
+      projectDir = mkdtempSync(join(tmpdir(), "powerline-project-test-"));
+      mkdirSync(join(projectDir, ".git"), { recursive: true });
+
+      writeFileSync(
+        join(tempDir, ".git"),
+        "gitdir: /repo/.git/worktrees/feature",
+      );
+      mockExec.mockImplementation(
+        createMockExec("feature-branch", WORKTREE_DIRS),
+      );
+
+      const info = await gitService.getGitInfo(
+        tempDir,
+        { showWorktree: true },
+        projectDir,
+      );
+
+      expect(info).not.toBeNull();
+      expect(info!.isWorktree).toBe(true);
+      expect(info!.branch).toBe("feature-branch");
+      for (const [, options] of mockExec.mock.calls) {
+        expect(options.cwd).toBe(tempDir);
+      }
     });
   });
 });

--- a/test/segments.test.ts
+++ b/test/segments.test.ts
@@ -1,6 +1,6 @@
 import { BlockProvider } from "../src/segments/block";
 import { TodayProvider } from "../src/segments/today";
-import { SegmentRenderer } from "../src/segments/renderer";
+import { SegmentRenderer, shouldShowWorktree } from "../src/segments/renderer";
 import { CacheTimerProvider } from "../src/segments/cacheTimer";
 import {
   formatCacheTimerElapsed,
@@ -365,11 +365,9 @@ describe("Segment Time Logic", () => {
 
       expect(renderer.renderAgent(base, colors, { enabled: true })).toBeNull();
       expect(
-        renderer.renderAgent(
-          { ...base, agent: { name: "   " } },
-          colors,
-          { enabled: true },
-        ),
+        renderer.renderAgent({ ...base, agent: { name: "   " } }, colors, {
+          enabled: true,
+        }),
       ).toBeNull();
     });
   });
@@ -1048,6 +1046,86 @@ describe("Segment Time Logic", () => {
     });
   });
 
+  describe("Git worktree indicator (issue #94)", () => {
+    const symbols = {
+      branch: "⎇",
+      git_clean: "✓",
+      git_dirty: "●",
+      git_worktree: "⧉",
+    } as any;
+    const colors = { gitBg: "", gitFg: "" } as any;
+    const config = {
+      theme: "dark",
+      display: { style: "minimal", lines: [] },
+    } as any;
+    const renderer = new SegmentRenderer(config, symbols);
+    const gitInfo = {
+      branch: "main",
+      status: "clean",
+      ahead: 0,
+      behind: 0,
+      isWorktree: true,
+    } as any;
+
+    it("renders ⧉ when the service reported a worktree", () => {
+      const git = renderer.renderGit(gitInfo, colors, { enabled: true });
+      expect(git!.text).toContain("⧉");
+    });
+
+    it("does not render ⧉ when isWorktree is false", () => {
+      const git = renderer.renderGit(
+        { ...gitInfo, isWorktree: false },
+        colors,
+        {
+          enabled: true,
+        },
+      );
+      expect(git!.text).not.toContain("⧉");
+    });
+
+    it("does not render ⧉ when the service was not asked to detect it", () => {
+      const git = renderer.renderGit(
+        { ...gitInfo, isWorktree: undefined },
+        colors,
+        { enabled: true },
+      );
+      expect(git!.text).not.toContain("⧉");
+    });
+
+    describe("shouldShowWorktree", () => {
+      it("follows showRepoName when showWorktree is unset", () => {
+        expect(shouldShowWorktree({ enabled: true, showRepoName: true })).toBe(
+          true,
+        );
+        expect(shouldShowWorktree({ enabled: true, showRepoName: false })).toBe(
+          false,
+        );
+      });
+
+      it("decouples the indicator when showWorktree is set explicitly", () => {
+        expect(
+          shouldShowWorktree({
+            enabled: true,
+            showRepoName: false,
+            showWorktree: true,
+          }),
+        ).toBe(true);
+        expect(
+          shouldShowWorktree({
+            enabled: true,
+            showRepoName: true,
+            showWorktree: false,
+          }),
+        ).toBe(false);
+      });
+
+      it("is off when nothing is configured", () => {
+        expect(shouldShowWorktree()).toBe(false);
+        expect(shouldShowWorktree({ enabled: true })).toBe(false);
+      });
+    });
+  });
+
   describe("CacheTimer Segment", () => {
     it("formats elapsed seconds across all thresholds", () => {
       expect(formatCacheTimerElapsed(0)).toBe("0:00");
@@ -1273,19 +1351,15 @@ describe("Segment Time Logic", () => {
       } as any;
       const renderer = new SegmentRenderer(config, symbols);
 
-      const fresh = renderer.renderCacheTimer(
-        { elapsedSeconds: 10 },
-        colors,
-        { displayMode: "remaining" } as any,
-      );
+      const fresh = renderer.renderCacheTimer({ elapsedSeconds: 10 }, colors, {
+        displayMode: "remaining",
+      } as any);
       expect(fresh.text).toContain("59:50");
       expect(fresh.bgColor).toBe(colors.cacheTimerBg);
 
-      const warn = renderer.renderCacheTimer(
-        { elapsedSeconds: 3500 },
-        colors,
-        { displayMode: "remaining" } as any,
-      );
+      const warn = renderer.renderCacheTimer({ elapsedSeconds: 3500 }, colors, {
+        displayMode: "remaining",
+      } as any);
       expect(warn.bgColor).toBe(colors.contextWarningBg);
 
       const critical = renderer.renderCacheTimer(
@@ -1295,11 +1369,9 @@ describe("Segment Time Logic", () => {
       );
       expect(critical.bgColor).toBe(colors.contextCriticalBg);
 
-      const cold = renderer.renderCacheTimer(
-        { elapsedSeconds: 7200 },
-        colors,
-        { displayMode: "remaining" } as any,
-      );
+      const cold = renderer.renderCacheTimer({ elapsedSeconds: 7200 }, colors, {
+        displayMode: "remaining",
+      } as any);
       expect(cold.text).toContain("cold");
       expect(cold.bgColor).toBe(colors.contextCriticalBg);
 
@@ -1392,7 +1464,11 @@ describe("Segment Time Logic", () => {
     const cases: Array<{
       name: string;
       opts: Parameters<typeof renderTodayCase>[0];
-      expected: { isNull: boolean; textContains?: string[]; textEquals?: string };
+      expected: {
+        isNull: boolean;
+        textContains?: string[];
+        textEquals?: string;
+      };
     }> = [
       {
         name: "default flags (both true) -> value + percentage",

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -434,6 +434,32 @@ describe("TUI Panel Rendering", () => {
       expect(result["metrics.added"]).toContain(SYMBOLS.metrics_lines_added);
     });
 
+    it("renders the worktree indicator in the git segment and its own token", () => {
+      const config: PowerlineConfig = {
+        ...DEFAULT_CONFIG,
+        display: { ...DEFAULT_CONFIG.display, style: "tui" },
+      };
+      const data = makeTuiData();
+      data.gitInfo!.isWorktree = true;
+      const { data: result } = resolveSegments(data, mkCtx(config, data));
+
+      expect(result["git.worktree"]).toContain(SYMBOLS.git_worktree);
+      expect(result["git"]).toContain(SYMBOLS.git_worktree);
+      expect(result["git.head"]).toContain(SYMBOLS.git_worktree);
+    });
+
+    it("omits the worktree indicator when the git service did not report one", () => {
+      const config: PowerlineConfig = {
+        ...DEFAULT_CONFIG,
+        display: { ...DEFAULT_CONFIG.display, style: "tui" },
+      };
+      const data = makeTuiData();
+      const { data: result } = resolveSegments(data, mkCtx(config, data));
+
+      expect(result["git.worktree"]).toBe("");
+      expect(result["git"]).not.toContain(SYMBOLS.git_worktree);
+    });
+
     it("per-segment showIcon overrides global showIcons", () => {
       const config: PowerlineConfig = {
         ...DEFAULT_CONFIG,


### PR DESCRIPTION
## Summary

Adds a `showWorktree` config option to the git segment so the ⧉ worktree
indicator can be shown independently of `showRepoName`. Previously the
marker was nested inside the repo-name render branch (both in the
renderer and in the git service's data layer), so users had to
permanently enable `showRepoName` just to see the worktree indicator.

This implements option 1 from the issue (a dedicated `showWorktree`
flag), with defaults unchanged — existing configs render identically
unless a user opts in.

## Changes

- `src/segments/renderer.ts`: `GitSegmentConfig` gains `showWorktree?: boolean`;
  `renderGit` now pushes the ⧉ symbol when `(showRepoName || showWorktree) && isWorktree`,
  decoupled from the repoName push.
- `src/segments/git.ts`: `getGitInfo` options gain `showWorktree?: boolean`;
  `result.isWorktree` is now populated when either `showRepoName` or
  `showWorktree` is requested (previously `showRepoName` only). This is
  the actual root cause — the renderer never even received `isWorktree`
  for a repo-name-less config, so a renderer-only fix would have been
  incomplete.
- `src/powerline.ts`: wires `config.showWorktree` through to `getGitInfo`
  in the real (non-TUI) render path.
- `src/config/defaults.ts`: `showWorktree: false` added to the git
  segment defaults (behavior unchanged out of the box).
- `README.md`: documents the new option, and adds the ⧉ symbol to the
  Symbols list (it was previously used but undocumented).

## Backward compatibility

The gate is `showRepoName || showWorktree` rather than a `showWorktree`-only
check, so even non-default existing configs (e.g. someone with
`showRepoName: true` already) see zero behavior change.

## Tests

Regression coverage added in two places (matching the two layers of the
root cause):
- `test/segments.test.ts`: renderer-level assertions that ⧉ renders when
  `showWorktree: true` regardless of `showRepoName`, and does not render
  when neither flag is set or `isWorktree` is false.
- `test/git-worktree.test.ts`: git-service-level assertions that
  `getGitInfo(...).isWorktree` is populated when `showWorktree` is
  requested without `showRepoName`, and left `undefined` when neither
  is requested.

Verified these tests fail (TS2561, unknown property `showWorktree`)
before the fix and pass after, via a temporary `git stash` of the
source changes.

```
Test Suites: 13 passed, 13 total
Tests:       265 passed, 265 total
```

`npm run lint` and `npm run typecheck` both pass clean.

Closes #94