### PR TITLE
feat(models): prettify Fable and Mythos model names

### DIFF
--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -64,7 +64,7 @@ export function formatDuration(seconds: number): string {
 }
 
 const CLAUDE_MODEL_PATTERN =
-  /^(?:(?:global|apac|au|eu|us|us-east-\d|us-west-\d|eu-west-\d|eu-central-\d)\.)?(?:anthropic\.|azure_ai\/|bedrock\/|vertex_ai\/)?claude-(?:(?<family>opus|sonnet|haiku)-(?<newMajor>\d+)(?:-(?<newMinor>\d))?|(?<oldMajor>\d+)(?:-(?<oldMinor>\d))?-(?<oldFamily>opus|sonnet|haiku))(?:[-@]\d{8})?(?:-v\d+:\d+)?(?:-latest)?$/i;
+  /^(?:(?:global|apac|au|eu|us|us-east-\d|us-west-\d|eu-west-\d|eu-central-\d)\.)?(?:anthropic\.|azure_ai\/|bedrock\/|vertex_ai\/)?claude-(?:(?<family>opus|sonnet|haiku|fable|mythos)-(?<newMajor>\d+)(?:-(?<newMinor>\d))?|(?<oldMajor>\d+)(?:-(?<oldMinor>\d))?-(?<oldFamily>opus|sonnet|haiku|fable|mythos))(?:[-@]\d{8})?(?:-v\d+:\d+)?(?:-latest)?$/i;
 
 export function formatModelName(rawName: string): string {
   if (!rawName) {

--- a/test/formatters.test.ts
+++ b/test/formatters.test.ts
@@ -49,7 +49,6 @@ describe("formatModelName", () => {
         "Sonnet 3",
       );
     });
-
   });
 
   describe("GCP Vertex AI models", () => {
@@ -82,6 +81,19 @@ describe("formatModelName", () => {
       expect(formatModelName("azure_ai/claude-haiku-4-5")).toBe("Haiku 4.5");
       expect(formatModelName("azure_ai/claude-opus-4-1")).toBe("Opus 4.1");
       expect(formatModelName("azure_ai/claude-sonnet-4-5")).toBe("Sonnet 4.5");
+    });
+  });
+
+  describe("Fable and Mythos models", () => {
+    it("should parse Fable and Mythos API model IDs", () => {
+      expect(formatModelName("claude-fable-5")).toBe("Fable 5");
+      expect(formatModelName("claude-mythos-5")).toBe("Mythos 5");
+    });
+
+    it("should parse Fable and Mythos gateway model IDs", () => {
+      expect(formatModelName("anthropic.claude-fable-5")).toBe("Fable 5");
+      expect(formatModelName("us.anthropic.claude-mythos-5")).toBe("Mythos 5");
+      expect(formatModelName("vertex_ai/claude-fable-5")).toBe("Fable 5");
     });
   });
 


### PR DESCRIPTION
## Summary
`CLAUDE_MODEL_PATTERN` in `src/utils/formatters.ts` only recognized `opus|sonnet|haiku`, so sessions where `model.display_name` carries a raw model id (Bedrock/Vertex/Azure gateways) rendered `claude-fable-5` verbatim in the model segment, while equivalent opus/sonnet ids were prettified to "Opus 4.5" etc. This adds `fable` and `mythos` to both family alternations, so those ids render as "Fable 5" / "Mythos 5".

Display-only change — no pricing or context-limit changes. Fable pricing is already covered by the weekly `pricing.json` sync (since 2026-07-05), and context size comes from Claude Code's native `context_window` hook data. Supersedes the display portion of #92; thanks @chesterXalan for the original report.

## Testing
- `npm test` — 262 passed (2 new formatter tests: plain and gateway-prefixed fable/mythos ids)
- `npm run lint` / `tsc --noEmit` clean