### PR TITLE
fix: include subagent transcript mtimes in cache invalidation check

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -8,6 +8,7 @@ import {
   getClaudePaths,
   findProjectPaths,
   getFileModificationDate,
+  collectProjectFiles,
 } from "./claude";
 
 interface ErrnoError extends Error {
@@ -213,32 +214,25 @@ export class CacheManager {
     }
   }
 
+  /**
+   * Newest mtime across every transcript the cost segments read. It must cover
+   * the same files as collectProjectFiles: when it saw only top-level session
+   * transcripts, agent usage could land without moving this timestamp, so the
+   * today cache stayed valid while session cost had already grown past it
+   * (issue #98).
+   */
   static async getLatestTranscriptMtime(): Promise<number> {
     try {
       const claudePaths = getClaudePaths();
       const projectPaths = await findProjectPaths(claudePaths);
 
-      let latestMtime = 0;
+      const fileGroups = await Promise.all(
+        projectPaths.map((projectPath) => collectProjectFiles(projectPath)),
+      );
 
-      for (const projectPath of projectPaths) {
-        try {
-          const files = await fs.promises.readdir(projectPath);
-          const jsonlFiles = files.filter((file) => file.endsWith(".jsonl"));
-
-          for (const file of jsonlFiles) {
-            const filePath = path.join(projectPath, file);
-            const mtime = await getFileModificationDate(filePath);
-            if (mtime && mtime.getTime() > latestMtime) {
-              latestMtime = mtime.getTime();
-            }
-          }
-        } catch (error) {
-          debug(`Failed to read project directory ${projectPath}:`, error);
-          continue;
-        }
-      }
-
-      return latestMtime;
+      return fileGroups
+        .flat()
+        .reduce((latest, file) => Math.max(latest, file.mtime.getTime()), 0);
     } catch (error) {
       debug("Failed to get latest transcript mtime:", error);
       return Date.now();

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -156,37 +156,70 @@ export async function findTranscriptFile(
   return null;
 }
 
+/**
+ * Lists every agent transcript belonging to a session. Agents write to
+ * <session>/subagents/agent-*.jsonl, and workflow agents nest further under
+ * subagents/workflows/<runId>/, so the walk has to recurse.
+ *
+ * This is the single definition of where agent usage lives. Session cost,
+ * daily cost and the cache-invalidation mtime check all go through it, so
+ * they cannot disagree about which files count.
+ */
+export async function findAgentTranscriptPaths(
+  sessionDir: string,
+): Promise<string[]> {
+  const paths: string[] = [];
+
+  const walk = async (dir: string): Promise<void> => {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      // Sessions without agents have no subagents directory at all.
+      return;
+    }
+
+    for (const entry of entries) {
+      const entryPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(entryPath);
+      } else if (
+        entry.name.startsWith("agent-") &&
+        entry.name.endsWith(".jsonl")
+      ) {
+        paths.push(entryPath);
+      }
+    }
+  };
+
+  await walk(join(sessionDir, "subagents"));
+
+  return paths;
+}
+
 export async function findAgentTranscripts(
   sessionId: string,
   projectPath: string,
 ): Promise<string[]> {
   const agentFiles: string[] = [];
 
-  const subagentsDir = join(projectPath, sessionId, "subagents");
+  const candidates = await findAgentTranscriptPaths(
+    join(projectPath, sessionId),
+  );
 
-  try {
-    const files = await readdir(subagentsDir);
-    const agentFileNames = files.filter(
-      (f) => f.startsWith("agent-") && f.endsWith(".jsonl"),
-    );
-
-    for (const fileName of agentFileNames) {
-      const filePath = join(subagentsDir, fileName);
-      try {
-        const content = await readFile(filePath, "utf-8");
-        const firstLine = content.split("\n")[0];
-        if (firstLine) {
-          const parsed = JSON.parse(firstLine);
-          if (parsed.sessionId === sessionId) {
-            agentFiles.push(filePath);
-          }
+  for (const filePath of candidates) {
+    try {
+      const content = await readFile(filePath, "utf-8");
+      const firstLine = content.split("\n")[0];
+      if (firstLine) {
+        const parsed = JSON.parse(firstLine);
+        if (parsed.sessionId === sessionId) {
+          agentFiles.push(filePath);
         }
-      } catch {
-        debug(`Failed to check agent file ${filePath}`);
       }
+    } catch {
+      debug(`Failed to check agent file ${filePath}`);
     }
-  } catch (error) {
-    debug(`Failed to read subagents directory ${subagentsDir}:`, error);
   }
 
   return agentFiles;
@@ -414,7 +447,7 @@ async function statFile(filePath: string): Promise<FileStat | null> {
   }
 }
 
-async function collectProjectFiles(
+export async function collectProjectFiles(
   projectPath: string,
   fileFilter?: (filePath: string, modTime: Date) => boolean,
 ): Promise<FileStat[]> {
@@ -428,15 +461,8 @@ async function collectProjectFiles(
     const subagentFiles = entries
       .filter((e) => e.isDirectory())
       .map(async (e) => {
-        const subagentsDir = join(projectPath, e.name, "subagents");
-        try {
-          const files = await readdir(subagentsDir);
-          return files
-            .filter((f) => f.startsWith("agent-") && f.endsWith(".jsonl"))
-            .map((f) => statFile(join(subagentsDir, f)));
-        } catch {
-          return [];
-        }
+        const paths = await findAgentTranscriptPaths(join(projectPath, e.name));
+        return paths.map((p) => statFile(p));
       });
 
     const [sessionResults, subagentResults] = await Promise.all([

--- a/test/claude-utils.test.ts
+++ b/test/claude-utils.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { findAgentTranscripts } from "../src/utils/claude";
+import { findAgentTranscripts, collectProjectFiles } from "../src/utils/claude";
+import { CacheManager } from "../src/utils/cache";
 
 describe("findAgentTranscripts", () => {
   let tempDir: string;
@@ -20,7 +21,11 @@ describe("findAgentTranscripts", () => {
     return subagentsDir;
   }
 
-  function writeAgentFile(subagentsDir: string, name: string, sessionId: string): string {
+  function writeAgentFile(
+    subagentsDir: string,
+    name: string,
+    sessionId: string,
+  ): string {
     const filePath = join(subagentsDir, name);
     writeFileSync(filePath, JSON.stringify({ sessionId }) + "\n");
     return filePath;
@@ -29,7 +34,11 @@ describe("findAgentTranscripts", () => {
   it("finds agent transcripts in <session-uuid>/subagents/", async () => {
     const sessionId = "abc123";
     const subagentsDir = makeSubagentsDir(sessionId);
-    const agentFile = writeAgentFile(subagentsDir, "agent-a1b2c3.jsonl", sessionId);
+    const agentFile = writeAgentFile(
+      subagentsDir,
+      "agent-a1b2c3.jsonl",
+      sessionId,
+    );
 
     const result = await findAgentTranscripts(sessionId, tempDir);
 
@@ -77,12 +86,131 @@ describe("findAgentTranscripts", () => {
     const sessionId = "abc123";
     const subagentsDir = makeSubagentsDir(sessionId);
     writeAgentFile(subagentsDir, "agent-valid.jsonl", sessionId);
-    writeFileSync(join(subagentsDir, "agent-ignored.txt"), JSON.stringify({ sessionId }) + "\n");
-    writeFileSync(join(subagentsDir, "other.jsonl"), JSON.stringify({ sessionId }) + "\n");
+    writeFileSync(
+      join(subagentsDir, "agent-ignored.txt"),
+      JSON.stringify({ sessionId }) + "\n",
+    );
+    writeFileSync(
+      join(subagentsDir, "other.jsonl"),
+      JSON.stringify({ sessionId }) + "\n",
+    );
 
     const result = await findAgentTranscripts(sessionId, tempDir);
 
     expect(result).toHaveLength(1);
     expect(result[0]).toContain("agent-valid.jsonl");
+  });
+
+  it("finds workflow agent transcripts nested under subagents/workflows/", async () => {
+    const sessionId = "abc123";
+    const subagentsDir = makeSubagentsDir(sessionId);
+    writeAgentFile(subagentsDir, "agent-top.jsonl", sessionId);
+
+    const workflowDir = join(subagentsDir, "workflows", "wf_deadbeef");
+    mkdirSync(workflowDir, { recursive: true });
+    writeAgentFile(workflowDir, "agent-nested.jsonl", sessionId);
+
+    const result = await findAgentTranscripts(sessionId, tempDir);
+
+    expect(result).toHaveLength(2);
+    expect(result.some((f) => f.includes("agent-nested.jsonl"))).toBe(true);
+  });
+});
+
+describe("collectProjectFiles", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "powerline-collect-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("collects session transcripts alongside flat and nested agent transcripts", async () => {
+    writeFileSync(join(tempDir, "session.jsonl"), "{}\n");
+
+    const subagentsDir = join(tempDir, "session", "subagents");
+    mkdirSync(join(subagentsDir, "workflows", "wf_1"), { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-flat.jsonl"), "{}\n");
+    writeFileSync(
+      join(subagentsDir, "workflows", "wf_1", "agent-nested.jsonl"),
+      "{}\n",
+    );
+
+    const files = await collectProjectFiles(tempDir);
+    const names = files.map((f) => f.filePath.split(/[\\/]/).pop());
+
+    expect(names.sort()).toEqual([
+      "agent-flat.jsonl",
+      "agent-nested.jsonl",
+      "session.jsonl",
+    ]);
+  });
+});
+
+describe("CacheManager.getLatestTranscriptMtime", () => {
+  let claudeDir: string;
+  let projectDir: string;
+
+  beforeEach(() => {
+    claudeDir = mkdtempSync(join(tmpdir(), "powerline-mtime-test-"));
+    projectDir = join(claudeDir, "projects", "some-project");
+    mkdirSync(projectDir, { recursive: true });
+    process.env.CLAUDE_CONFIG_DIR = claudeDir;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    rmSync(claudeDir, { recursive: true, force: true });
+  });
+
+  const AGENT_MTIME = new Date("2026-07-21T12:00:00Z");
+
+  function writeAgedFile(filePath: string, mtime: Date): void {
+    mkdirSync(join(filePath, ".."), { recursive: true });
+    writeFileSync(filePath, "{}\n");
+    utimesSync(filePath, mtime, mtime);
+  }
+
+  beforeEach(() => {
+    // An older session transcript, so only an agent file can raise the mtime.
+    writeAgedFile(
+      join(projectDir, "session.jsonl"),
+      new Date("2026-07-21T10:00:00Z"),
+    );
+  });
+
+  // Regression tests for issue #98: agent usage that lands after the session
+  // transcript was last written has to move this timestamp, or the today cache
+  // is served stale while session cost keeps climbing past it.
+  it("reflects agent transcripts under subagents/", async () => {
+    writeAgedFile(
+      join(projectDir, "session", "subagents", "agent-flat.jsonl"),
+      AGENT_MTIME,
+    );
+
+    expect(await CacheManager.getLatestTranscriptMtime()).toBe(
+      AGENT_MTIME.getTime(),
+    );
+  });
+
+  it("reflects workflow agent transcripts nested deeper still", async () => {
+    writeAgedFile(
+      join(
+        projectDir,
+        "session",
+        "subagents",
+        "workflows",
+        "wf_1",
+        "agent-nested.jsonl",
+      ),
+      AGENT_MTIME,
+    );
+
+    expect(await CacheManager.getLatestTranscriptMtime()).toBe(
+      AGENT_MTIME.getTime(),
+    );
   });
 });


### PR DESCRIPTION
Suggested copilot's fix for issue: https://github.com/Owloops/claude-powerline/issues/98