### PR TITLE
fix(tui): accept git.worktree in grid cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,9 +858,10 @@ Here `context.bar` spans the first three columns.
 Use bare segment names to render the full pre-formatted segment:
 
 ```
-context  block  session  today   weekly
-git      dir    version  tmux    metrics
-activity env    agent
+context  block    session  today    weekly
+git      dir      model    version  tmux
+metrics  activity env      agent    thinking
+cacheTimer
 ```
 
 #### Dot-Notation Subsegments
@@ -869,20 +870,22 @@ Use `segment.part` to place individual pieces of a segment into separate cells w
 
 | Segment | Parts |
 |---|---|
-| `git` | `icon`, `branch`, `status`, `ahead`, `behind`, `working`, `head` |
-| `context` | `icon`, `bar`, `pct`, `tokens` |
-| `block` | `icon`, `bar`, `value`, `time`, `budget` |
-| `session` | `icon`, `cost`, `tokens`, `budget` |
+| `session` | `icon`, `label`, `cost`, `tokens`, `budget` |
+| `block` | `icon`, `label`, `value`, `time`, `budget`, `bar` |
 | `today` | `icon`, `cost`, `label`, `budget` |
-| `weekly` | `icon`, `bar`, `pct`, `time` |
+| `weekly` | `icon`, `label`, `pct`, `time`, `bar` |
+| `git` | `icon`, `headVal`, `branch`, `status`, `ahead`, `behind`, `working`, `worktree`, `head` |
+| `context` | `icon`, `label`, `bar`, `pct`, `tokens` |
 | `metrics` | `response`, `responseIcon`, `responseVal`, `lastResponse`, `lastResponseIcon`, `lastResponseVal`, `added`, `addedIcon`, `addedVal`, `removed`, `removedIcon`, `removedVal` |
-| `activity` | `duration`, `durationIcon`, `durationVal`, `messages`, `messagesIcon`, `messagesVal` |
+| `activity` | `icon`, `duration`, `durationIcon`, `durationVal`, `messages`, `messagesIcon`, `messagesVal` |
+| `model` | `icon`, `value` |
 | `version` | `icon`, `value` |
 | `tmux` | `label`, `value` |
-| `dir` | `value` |
+| `dir` | `icon`, `value` |
 | `env` | `prefix`, `value` |
 | `agent` | `icon`, `name` |
 | `thinking` | `icon`, `enabled`, `effort` |
+| `cacheTimer` | `icon`, `value` |
 
 Example, block segment with a progress bar, mirroring the context layout:
 

--- a/src/tui/sections.ts
+++ b/src/tui/sections.ts
@@ -5,6 +5,8 @@ import type {
   SymbolSet,
   BoxChars,
   RenderCtx,
+  SegmentName,
+  SegmentParts,
   SegmentTemplate,
   JustifyValue,
   TuiTitleConfig,
@@ -27,6 +29,7 @@ import {
 } from "../utils/formatters";
 import { resolveBudgetDisplay } from "../utils/budget";
 import type { CacheTimerSegmentConfig } from "../segments/renderer";
+import { segmentPartNames } from "./types";
 import { colorize, truncateAnsi } from "./primitives";
 import { getEffortLevel, getThinkingEnabled } from "../utils/claude";
 import { resolveIconVisibility } from "../utils/icon-visibility";
@@ -154,7 +157,7 @@ export function formatContextParts(
   data: TuiData,
   sym: SymbolSet,
   iconVisible = true,
-): Record<string, string> {
+): SegmentParts<"context"> {
   if (!data.contextInfo)
     return { icon: "", label: "context", bar: "", pct: "", tokens: "" };
 
@@ -537,7 +540,7 @@ export function formatBlockParts(
   sym: SymbolSet,
   _config: PowerlineConfig,
   iconVisible = true,
-): Record<string, string> {
+): SegmentParts<"block"> {
   const value = `${Math.round(blockInfo.nativeUtilization)}%`;
   const time = formatTimeRemaining(blockInfo.timeRemaining);
 
@@ -568,7 +571,7 @@ export function formatWeeklyParts(
   sevenDay: { used_percentage: number; resets_at: number },
   sym: SymbolSet,
   iconVisible = true,
-): Record<string, string> {
+): SegmentParts<"weekly"> {
   const pct = `${Math.round(sevenDay.used_percentage)}%`;
   const time = formatLongTimeRemaining(minutesUntilReset(sevenDay.resets_at));
   return {
@@ -596,7 +599,7 @@ export function formatSessionParts(
   sym: SymbolSet,
   config: PowerlineConfig,
   iconVisible = true,
-): Record<string, string> {
+): SegmentParts<"session"> {
   const state = resolveBudgetDisplay(
     usageInfo.session.cost,
     usageInfo.session.tokens,
@@ -656,7 +659,7 @@ export function formatTodayParts(
   sym: SymbolSet,
   config: PowerlineConfig,
   iconVisible = true,
-): Record<string, string> {
+): SegmentParts<"today"> {
   const state = resolveBudgetDisplay(
     todayInfo.cost,
     todayInfo.tokens,
@@ -703,8 +706,8 @@ export function formatTodaySegment(
 function formatMetricsParts(
   data: TuiData,
   sym: SymbolSet,
-): Record<string, string> {
-  const empty = {
+): SegmentParts<"metrics"> {
+  const empty: SegmentParts<"metrics"> = {
     response: "",
     responseIcon: "",
     responseVal: "",
@@ -776,8 +779,8 @@ function formatMetricsSegment(data: TuiData, sym: SymbolSet): string {
 function formatActivityParts(
   data: TuiData,
   sym: SymbolSet,
-): Record<string, string> {
-  const empty = {
+): SegmentParts<"activity"> {
+  const empty: SegmentParts<"activity"> = {
     icon: "",
     duration: "",
     durationIcon: "",
@@ -820,7 +823,7 @@ function formatGitParts(
   data: TuiData,
   sym: SymbolSet,
   iconVisible = true,
-): Record<string, string> {
+): SegmentParts<"git"> {
   if (!data.gitInfo)
     return {
       icon: "",
@@ -907,7 +910,7 @@ function formatDirParts(
   config: PowerlineConfig,
   sym: SymbolSet,
   iconVisible = true,
-): Record<string, string> {
+): SegmentParts<"dir"> {
   return {
     icon: iconVisible ? sym.dir : "",
     value: formatDirValue(data, config),
@@ -933,7 +936,7 @@ function formatVersionParts(
   data: TuiData,
   sym: SymbolSet,
   iconVisible = true,
-): Record<string, string> {
+): SegmentParts<"version"> {
   if (!data.hookData.version) return { icon: "", value: "" };
   return {
     icon: iconVisible ? sym.version : "",
@@ -955,7 +958,7 @@ function formatAgentParts(
   data: TuiData,
   sym: SymbolSet,
   iconVisible = true,
-): Record<string, string> {
+): SegmentParts<"agent"> {
   const raw = data.hookData.agent?.name;
   if (typeof raw !== "string") return { icon: "", name: "" };
   const name = raw.trim();
@@ -1003,7 +1006,7 @@ function formatThinkingParts(
   sym: SymbolSet,
   thinkingConfig: { showEnabled?: boolean; showEffort?: boolean } | undefined,
   iconVisible = true,
-): Record<string, string> {
+): SegmentParts<"thinking"> {
   const showEnabled = thinkingConfig?.showEnabled ?? true;
   const showEffort = thinkingConfig?.showEffort ?? true;
   const enabled = showEnabled ? getThinkingEnabled(data.hookData) : null;
@@ -1060,7 +1063,7 @@ function formatCacheTimerParts(
   sym: SymbolSet,
   config?: CacheTimerSegmentConfig,
   iconVisible = true,
-): Record<string, string> {
+): SegmentParts<"cacheTimer"> {
   if (!data.cacheTimerInfo) return { icon: "", value: "" };
   return {
     icon: iconVisible ? sym.cache_timer : "",
@@ -1102,7 +1105,7 @@ function cacheTimerStyle(
   }
   return { fg: colors.cacheTimerFg, bold: colors.cacheTimerBold };
 }
-function formatTmuxParts(data: TuiData): Record<string, string> {
+function formatTmuxParts(data: TuiData): SegmentParts<"tmux"> {
   if (!data.tmuxSessionId) return { label: "", value: "" };
   return { label: "tmux", value: data.tmuxSessionId };
 }
@@ -1113,7 +1116,7 @@ function formatTmuxSegment(data: TuiData): string {
   return `${parts.label}:${parts.value}`;
 }
 
-function formatEnvParts(config: PowerlineConfig): Record<string, string> {
+function formatEnvParts(config: PowerlineConfig): SegmentParts<"env"> {
   const envConfig = config.display.lines
     .map((line) => line.segments.env)
     .find((env) => env?.enabled);
@@ -1131,16 +1134,22 @@ function formatEnvSegment(config: PowerlineConfig): string {
   return parts.prefix ? `${parts.prefix}:${parts.value}` : parts.value;
 }
 
-function addParts(
+function addParts<S extends SegmentName>(
   result: Record<string, string>,
-  segment: string,
-  parts: Record<string, string>,
+  segment: S,
+  parts: SegmentParts<S>,
   color: string,
   reset: string,
   partFg?: Record<string, string>,
   bold = false,
 ): void {
-  for (const [key, value] of Object.entries(parts)) {
+  // Driven by the registry, not by the formatter's own keys, so a part that
+  // config validation would reject can never reach the token namespace.
+  // The lookup widening is safe because `parts` is keyed by this same list;
+  // TypeScript just cannot correlate the two while `S` is still generic.
+  const values = parts as Record<string, string | undefined>;
+  for (const key of segmentPartNames(segment)) {
+    const value = values[key];
     const partKey = `${segment}.${key}`;
     const partColor = partFg?.[partKey] ?? partFg?.[segment] ?? color;
     result[partKey] = value ? colorize(value, partColor, reset, bold) : "";

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -64,7 +64,16 @@ export const VALID_SEGMENT_NAMES: ReadonlySet<string> = new Set<SegmentName>(
   SEGMENT_NAME_LIST,
 );
 
-export const SEGMENT_PARTS: Record<SegmentName, readonly string[]> = {
+/**
+ * Every part name a segment publishes as a `segment.part` token. This is the
+ * single source of truth: `addParts` publishes exactly these keys and
+ * `isValidSegmentRef` accepts exactly these refs, so the resolvable namespace
+ * and the validated namespace cannot disagree.
+ *
+ * Literal-typed for `SegmentParts<S>`; consumers should use `SEGMENT_PARTS`,
+ * which exposes the same value under a stable widened type.
+ */
+const SEGMENT_PART_NAMES = {
   session: ["icon", "label", "cost", "tokens", "budget"],
   block: ["icon", "label", "value", "time", "budget", "bar"],
   today: ["icon", "cost", "label", "budget"],
@@ -77,6 +86,7 @@ export const SEGMENT_PARTS: Record<SegmentName, readonly string[]> = {
     "ahead",
     "behind",
     "working",
+    "worktree",
     "head",
   ],
   context: ["icon", "label", "bar", "pct", "tokens"],
@@ -111,7 +121,26 @@ export const SEGMENT_PARTS: Record<SegmentName, readonly string[]> = {
   agent: ["icon", "name"],
   thinking: ["icon", "enabled", "effort"],
   cacheTimer: ["icon", "value"],
-} as const;
+} as const satisfies Record<SegmentName, readonly string[]>;
+
+export const SEGMENT_PARTS: Record<SegmentName, readonly string[]> =
+  SEGMENT_PART_NAMES;
+
+export function segmentPartNames<S extends SegmentName>(
+  segment: S,
+): (typeof SEGMENT_PART_NAMES)[S] {
+  return SEGMENT_PART_NAMES[segment];
+}
+
+/**
+ * The part names a segment's formatter must produce. Annotating every
+ * `format*Parts` return with this makes the compiler reject a formatter that
+ * omits a listed part, or that adds an unlisted one in an object literal.
+ */
+export type SegmentParts<S extends SegmentName> = Record<
+  (typeof SEGMENT_PART_NAMES)[S][number],
+  string
+>;
 
 export function isValidSegmentRef(name: string): boolean {
   if (name === "." || name === "---") return true;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { DEFAULT_CONFIG } from "../src/config/defaults";
 import { loadConfig, loadConfigFromCLI } from "../src/config/loader";
+import { SEGMENT_PARTS } from "../src/tui/types";
 
 jest.mock("node:fs");
 jest.mock("node:os");
@@ -337,6 +338,32 @@ describe("config", () => {
       });
       expect(config.display.tui).toBeUndefined();
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("cells but expected"));
+    });
+
+    it("should accept a worktree indicator as a grid cell", () => {
+      const config = loadWithGrid({
+        breakpoints: [{
+          minWidth: 0,
+          areas: ["git.worktree git.branch"],
+          columns: ["auto", "1fr"],
+        }],
+      });
+      expect(config.display.tui).toBeDefined();
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+
+    // Guards the boundary the runtime tokens are actually rejected at: a part
+    // can resolve in resolveSegments and still be turned away here.
+    it("should accept every part in the segment registry as a grid cell", () => {
+      const rejected = Object.entries(SEGMENT_PARTS)
+        .flatMap(([segment, parts]) => parts.map((part) => `${segment}.${part}`))
+        .filter((ref) => {
+          const config = loadWithGrid({
+            breakpoints: [{ minWidth: 0, areas: [ref], columns: ["1fr"] }],
+          });
+          return config.display.tui === undefined;
+        });
+      expect(rejected).toEqual([]);
     });
 
     it("should reject grid config with unknown segment name", () => {

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { renderTuiPanel } from "../src/tui/renderer";
 import {
   resolveSegments,
@@ -5,6 +7,7 @@ import {
   formatSessionParts,
 } from "../src/tui/sections";
 import type { TuiData, BoxChars, RenderCtx } from "../src/tui/types";
+import { isValidSegmentRef, SEGMENT_PARTS } from "../src/tui/types";
 import type { PowerlineColors } from "../src/themes";
 import type { PowerlineConfig } from "../src/config/loader";
 import { BOX_CHARS, SYMBOLS } from "../src/utils/constants";
@@ -128,6 +131,18 @@ function makeTuiData(overrides: Partial<TuiData> = {}): TuiData {
     ...overrides,
   };
 }
+
+const mkCtx = (config: PowerlineConfig, data: TuiData): RenderCtx => ({
+  lines: [],
+  data,
+  box: BOX_CHARS,
+  contentWidth: 96,
+  innerWidth: 98,
+  sym: SYMBOLS,
+  config,
+  reset: "",
+  colors: PLAIN_COLORS,
+});
 
 describe("TUI Panel Rendering", () => {
   describe("Wide layout (80+ cols)", () => {
@@ -386,18 +401,6 @@ describe("TUI Panel Rendering", () => {
   });
 
   describe("resolveSegments showIcons handling", () => {
-    const mkCtx = (config: PowerlineConfig, data: TuiData): RenderCtx => ({
-      lines: [],
-      data,
-      box: BOX_CHARS,
-      contentWidth: 96,
-      innerWidth: 98,
-      sym: SYMBOLS,
-      config,
-      reset: "",
-      colors: PLAIN_COLORS,
-    });
-
     it("strips leading icons from segments and composite tokens while keeping metrics icons and git status glyphs", () => {
       const config: PowerlineConfig = {
         ...DEFAULT_CONFIG,
@@ -575,6 +578,68 @@ describe("TUI Panel Rendering", () => {
       expect(result["cacheTimer.icon"]).toBe(SYMBOLS.cache_timer);
       expect(result["cacheTimer.value"]).toBe("59:50");
       expect(result["cacheTimer"]).toContain("59:50");
+    });
+  });
+
+  describe("SEGMENT_PARTS registry", () => {
+    // Every optional-data segment populated, so resolveSegments publishes the
+    // full token namespace rather than the subset the default fixture covers.
+    function resolveEverything(): Record<string, string> {
+      const base = makeTuiData();
+      const data = makeTuiData({
+        hookData: {
+          ...base.hookData,
+          rate_limits: {
+            seven_day: {
+              used_percentage: 42,
+              resets_at: Math.floor(Date.now() / 1000) + 4 * 24 * 3600,
+            },
+          },
+        },
+        gitInfo: {
+          branch: "main",
+          status: "dirty",
+          ahead: 1,
+          behind: 2,
+          staged: 1,
+          unstaged: 2,
+          untracked: 3,
+          isWorktree: true,
+        },
+        cacheTimerInfo: { elapsedSeconds: 30 },
+      });
+      return resolveSegments(data, mkCtx(tuiConfig, data)).data;
+    }
+
+    it("validates every token resolveSegments publishes", () => {
+      const rejected = Object.keys(resolveEverything()).filter(
+        (token) => !isValidSegmentRef(token),
+      );
+      expect(rejected).toEqual([]);
+    });
+
+    it("lists no part that resolveSegments never publishes", () => {
+      const result = resolveEverything();
+      const orphaned = Object.entries(SEGMENT_PARTS)
+        .flatMap(([segment, parts]) =>
+          parts.map((part) => `${segment}.${part}`),
+        )
+        .filter((ref) => !(ref in result));
+      expect(orphaned).toEqual([]);
+    });
+
+    it("matches the dot-notation table documented in the README", () => {
+      const readme = readFileSync(join(__dirname, "..", "README.md"), "utf8");
+      const documented = Object.fromEntries(
+        Array.from(
+          readme.matchAll(/^\| `(\w+)` \| ((?:`\w+`(?:, )?)+) \|$/gm),
+          ([, segment, parts]) => [
+            segment,
+            parts!.split(", ").map((part) => part.slice(1, -1)),
+          ],
+        ),
+      );
+      expect(documented).toEqual(SEGMENT_PARTS);
     });
   });
 


### PR DESCRIPTION
Fixes #100.

`formatGitParts` gained a `worktree` key in #95, and `addParts` published it as a template token, but `SEGMENT_PARTS` in `src/tui/types.ts` was never updated to list it. `isValidSegmentRef` validates grid cells against that table, so this was rejected at config load with `unknown segment name "git.worktree"` even though `{git.worktree}` resolved correctly in titles, footers, and segment templates:

```json
{ "display": { "tui": { "breakpoints": [
  { "minWidth": 0, "areas": ["git.worktree git.branch"], "columns": ["auto", "1fr"] }
] } } }
```

## Why this isn't a one-line change

The missing entry is a symptom. The registry and the `format*Parts` functions were two hand-maintained lists that had to agree, with nothing checking that they did — so the same bug can recur on the next segment. This makes them incapable of disagreeing:

- **`SegmentParts<S>`** derives each formatter's return type from the registry. Omitting a listed part, or adding an unlisted one to a returned object literal, is now a compile error. (The two formatters that return a named `const` are annotated too — excess-property checking doesn't fire through a named const.)
- **`addParts` publishes the registry's part names**, not the formatter's own keys. A part config validation would reject can no longer reach the token namespace at all. This matters because the type alone can't close it: an object assembled by spread still satisfies `SegmentParts<S>` while carrying extra keys at runtime.

## Public API

`SEGMENT_PARTS` keeps its existing `Record<SegmentName, readonly string[]>` type. The literal-typed value is module-private, so consumers of the browser entry point are unaffected — `SEGMENT_PARTS[seg].includes(someString)` would stop compiling against an `as const` type, and that pattern is exactly what `isValidSegmentRef` itself does. Verified against every usage in `powerline-studio`.

## Tests

- Every token `resolveSegments` publishes passes `isValidSegmentRef`, and every registry entry is published — the drift itself, in both directions.
- A grid config using `git.worktree` loads without warnings, plus every registry ref accepted as a grid cell. This crosses the boundary the failure was actually reported at; the registry tests alone would stay green if loader validation stopped consulting `isValidSegmentRef`.
- The README's dot-notation table is asserted against the registry.

Both new registry tests fail against `main`.

## README

The dot-notation table had drifted the same way and is now generated from the registry. Beyond `git.worktree` it was missing `git.headVal`, `activity.icon`, `dir.icon`, the `label` parts of `session`/`block`/`weekly`/`context`, and the `model` and `cacheTimer` rows entirely. The bare-segment-name list was missing `model`, `thinking`, and `cacheTimer`.
