### PR TITLE
feat(segments): add outputStyle segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,29 @@ Set `showEnabled: false` to hide the `On`/`Off` state, or `showEffort: false` to
 </details>
 
 <details>
+<summary><strong>Output Style</strong> - Shows the active Claude Code output style (<code>default</code>, <code>Explanatory</code>, <code>Learning</code>, or a custom style)</summary>
+
+Opt-in (`enabled: false` by default).
+
+```json
+"outputStyle": {
+  "enabled": true,
+  "showLabel": false,
+  "hideDefault": false
+}
+```
+
+Set `showLabel: true` to prefix the name with `style: `. Set `hideDefault: true` to omit the segment while the active style is `default` (compared case-insensitively), so the segment only appears once you switch away from the default style.
+
+**Display:** `✎ Explanatory` (or `✎ style: Explanatory` with `showLabel: true`)
+
+**Symbols:** `✎` Output Style (unicode) &#8226; `OS` Output Style (text)
+
+The style name comes from Claude Code on stdin and is rendered verbatim. Older Claude Code builds do not send it — the segment is then hidden entirely rather than rendered empty.
+
+</details>
+
+<details>
 <summary><strong>Cache Timer</strong> - Shows time since last turn, tracking Claude's 5-minute prompt cache TTL</summary>
 
 Opt-in (`enabled: false` by default).
@@ -860,7 +883,7 @@ Use bare segment names to render the full pre-formatted segment:
 ```
 context  block  session  today   weekly
 git      dir    version  tmux    metrics
-activity env    agent
+activity env    agent    outputStyle
 ```
 
 #### Dot-Notation Subsegments
@@ -883,6 +906,7 @@ Use `segment.part` to place individual pieces of a segment into separate cells w
 | `env` | `prefix`, `value` |
 | `agent` | `icon`, `name` |
 | `thinking` | `icon`, `enabled`, `effort` |
+| `outputStyle` | `icon`, `name` |
 
 Example, block segment with a progress bar, mirroring the context layout:
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -51,6 +51,7 @@ export type {
   AgentSegmentConfig,
   ThinkingSegmentConfig,
   CacheTimerSegmentConfig,
+  OutputStyleSegmentConfig,
   PowerlineSymbols,
   SegmentData,
   BarDisplayStyle,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -62,6 +62,7 @@ export const DEFAULT_CONFIG: PowerlineConfig = {
           agent: { enabled: true, showLabel: false },
           thinking: { enabled: false, showEnabled: true, showEffort: true },
           cacheTimer: { enabled: false },
+          outputStyle: { enabled: false, showLabel: false, hideDefault: false },
         },
       },
     ],

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -23,6 +23,7 @@ import type {
   AgentSegmentConfig,
   ThinkingSegmentConfig,
   CacheTimerSegmentConfig,
+  OutputStyleSegmentConfig,
 } from "../segments/renderer";
 
 export interface LineConfig {
@@ -43,6 +44,7 @@ export interface LineConfig {
     agent?: AgentSegmentConfig;
     thinking?: ThinkingSegmentConfig;
     cacheTimer?: CacheTimerSegmentConfig;
+    outputStyle?: OutputStyleSegmentConfig;
   };
 }
 

--- a/src/powerline.ts
+++ b/src/powerline.ts
@@ -21,6 +21,7 @@ import type {
   AgentSegmentConfig,
   ThinkingSegmentConfig,
   CacheTimerSegmentConfig,
+  OutputStyleSegmentConfig,
 } from "./segments";
 import type { BlockInfo } from "./segments/block";
 import type { TodayInfo } from "./segments/today";
@@ -630,6 +631,14 @@ export class PowerlineRenderer {
       );
     }
 
+    if (segment.type === "outputStyle") {
+      return this.segmentRenderer.renderOutputStyle(
+        hookData,
+        colors,
+        segment.config as OutputStyleSegmentConfig,
+      );
+    }
+
     return null;
   }
 
@@ -768,6 +777,7 @@ export class PowerlineRenderer {
       agent: symbolSet.agent,
       thinking: symbolSet.thinking,
       cache_timer: symbolSet.cache_timer,
+      output_style: symbolSet.output_style,
     };
   }
 
@@ -848,6 +858,7 @@ export class PowerlineRenderer {
     const agent = getSegmentColors("agent");
     const thinking = getSegmentColors("thinking");
     const cacheTimer = getSegmentColors("cacheTimer");
+    const outputStyle = getSegmentColors("outputStyle");
 
     return {
       reset: colorSupport === "none" ? "" : RESET_CODE,
@@ -902,6 +913,9 @@ export class PowerlineRenderer {
       cacheTimerBg: cacheTimer.bg,
       cacheTimerFg: cacheTimer.fg,
       cacheTimerBold: cacheTimer.bold,
+      outputStyleBg: outputStyle.bg,
+      outputStyleFg: outputStyle.fg,
+      outputStyleBold: outputStyle.bold,
       partFg: theme === "custom" ? this.resolvePartColors(convertHex) : {},
     };
   }
@@ -959,6 +973,8 @@ export class PowerlineRenderer {
         return colors.thinkingBg;
       case "cacheTimer":
         return colors.cacheTimerBg;
+      case "outputStyle":
+        return colors.outputStyleBg;
       default:
         return colors.modeBg;
     }
@@ -1000,6 +1016,8 @@ export class PowerlineRenderer {
         return colors.thinkingBold;
       case "cacheTimer":
         return colors.cacheTimerBold;
+      case "outputStyle":
+        return colors.outputStyleBold;
       default:
         return colors.modeBold;
     }

--- a/src/segments/index.ts
+++ b/src/segments/index.ts
@@ -27,4 +27,5 @@ export type {
   AgentSegmentConfig,
   ThinkingSegmentConfig,
   CacheTimerSegmentConfig,
+  OutputStyleSegmentConfig,
 } from "./renderer";

--- a/src/segments/renderer.ts
+++ b/src/segments/renderer.ts
@@ -1,5 +1,9 @@
 import type { ClaudeHookData } from "../utils/claude";
-import { getEffortLevel, getThinkingEnabled } from "../utils/claude";
+import {
+  getEffortLevel,
+  getOutputStyleName,
+  getThinkingEnabled,
+} from "../utils/claude";
 import type { PowerlineColors } from "../themes";
 import type { PowerlineConfig } from "../config/loader";
 import type { BlockInfo } from "./block";
@@ -146,6 +150,13 @@ export interface CacheTimerSegmentConfig extends SegmentConfig {
   ttlSeconds?: number;
 }
 
+export interface OutputStyleSegmentConfig extends SegmentConfig {
+  /** Render "style: <name>" instead of the bare name (default: false). */
+  showLabel?: boolean;
+  /** Omit the segment when the active style is "default" (default: false). */
+  hideDefault?: boolean;
+}
+
 export type AnySegmentConfig =
   | SegmentConfig
   | DirectorySegmentConfig
@@ -162,7 +173,8 @@ export type AnySegmentConfig =
   | WeeklySegmentConfig
   | AgentSegmentConfig
   | ThinkingSegmentConfig
-  | CacheTimerSegmentConfig;
+  | CacheTimerSegmentConfig
+  | OutputStyleSegmentConfig;
 
 export interface PowerlineSymbols {
   right: string;
@@ -200,6 +212,7 @@ export interface PowerlineSymbols {
   agent: string;
   thinking: string;
   cache_timer: string;
+  output_style: string;
 }
 
 export interface SegmentData {
@@ -961,5 +974,24 @@ export class SegmentRenderer {
     }
 
     return { text, bgColor, fgColor, bold };
+  }
+
+  renderOutputStyle(
+    hookData: ClaudeHookData,
+    colors: PowerlineColors,
+    config?: OutputStyleSegmentConfig,
+  ): SegmentData | null {
+    const name = getOutputStyleName(hookData);
+    if (!name) return null;
+    if (config?.hideDefault && name.toLowerCase() === "default") return null;
+
+    const iconPrefix = this.leadingIcon(this.symbols.output_style, config);
+    const body = config?.showLabel ? `style: ${name}` : name;
+
+    return {
+      text: `${iconPrefix}${body}`,
+      bgColor: colors.outputStyleBg,
+      fgColor: colors.outputStyleFg,
+    };
   }
 }

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -18,6 +18,7 @@ export const darkTheme: ColorTheme = {
   agent: { bg: "#2a2a4a", fg: "#b0a8e0" },
   thinking: { bg: "#2a2a3a", fg: "#c792ea" },
   cacheTimer: { bg: "#1f3a1f", fg: "#90ee90" },
+  outputStyle: { bg: "#1f3a3a", fg: "#7fd1c4" },
 };
 
 export const darkAnsi256Theme: ColorTheme = {
@@ -38,6 +39,7 @@ export const darkAnsi256Theme: ColorTheme = {
   agent: { bg: "#3a3a5f", fg: "#afafd7" },
   thinking: { bg: "#2a2a3a", fg: "#d787ff" },
   cacheTimer: { bg: "#1c2e1c", fg: "#87ff87" },
+  outputStyle: { bg: "#1c3030", fg: "#5fd7d7" },
 };
 
 export const darkAnsiTheme: ColorTheme = {
@@ -58,4 +60,5 @@ export const darkAnsiTheme: ColorTheme = {
   agent: { bg: "#444444", fg: "#af87ff" },
   thinking: { bg: "#444444", fg: "#ff87ff" },
   cacheTimer: { bg: "#2f4f2f", fg: "#00ff00" },
+  outputStyle: { bg: "#444444", fg: "#00d7af" },
 };

--- a/src/themes/gruvbox.ts
+++ b/src/themes/gruvbox.ts
@@ -18,6 +18,7 @@ export const gruvboxTheme: ColorTheme = {
   agent: { bg: "#504945", fg: "#d3869b" },
   thinking: { bg: "#3c3046", fg: "#d3869b" },
   cacheTimer: { bg: "#3c3836", fg: "#b8bb26" },
+  outputStyle: { bg: "#2f3b34", fg: "#8ec07c" },
 };
 
 export const gruvboxAnsi256Theme: ColorTheme = {
@@ -38,6 +39,7 @@ export const gruvboxAnsi256Theme: ColorTheme = {
   agent: { bg: "#6c6c6c", fg: "#d787af" },
   thinking: { bg: "#444444", fg: "#d787af" },
   cacheTimer: { bg: "#444444", fg: "#afaf00" },
+  outputStyle: { bg: "#444444", fg: "#87af87" },
 };
 
 export const gruvboxAnsiTheme: ColorTheme = {
@@ -58,4 +60,5 @@ export const gruvboxAnsiTheme: ColorTheme = {
   agent: { bg: "#808080", fg: "#ff87af" },
   thinking: { bg: "#808080", fg: "#ff87af" },
   cacheTimer: { bg: "#585858", fg: "#ffff00" },
+  outputStyle: { bg: "#808080", fg: "#87d7af" },
 };

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -37,6 +37,7 @@ export interface ColorTheme {
   agent: SegmentColor;
   thinking: SegmentColor;
   cacheTimer: SegmentColor;
+  outputStyle: SegmentColor;
 }
 
 export interface PowerlineColors {
@@ -92,6 +93,9 @@ export interface PowerlineColors {
   cacheTimerBg: string;
   cacheTimerFg: string;
   cacheTimerBold: boolean;
+  outputStyleBg: string;
+  outputStyleFg: string;
+  outputStyleBold: boolean;
   partFg: Record<string, string>;
 }
 

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -18,6 +18,7 @@ export const lightTheme: ColorTheme = {
   agent: { bg: "#7c3aed", fg: "#ffffff" },
   thinking: { bg: "#7c3aed", fg: "#ffffff" },
   cacheTimer: { bg: "#059669", fg: "#ffffff" },
+  outputStyle: { bg: "#0f766e", fg: "#ffffff" },
 };
 
 export const lightAnsi256Theme: ColorTheme = {
@@ -38,6 +39,7 @@ export const lightAnsi256Theme: ColorTheme = {
   agent: { bg: "#8787d7", fg: "#ffffff" },
   thinking: { bg: "#8700d7", fg: "#ffffff" },
   cacheTimer: { bg: "#00875f", fg: "#ffffff" },
+  outputStyle: { bg: "#008787", fg: "#ffffff" },
 };
 
 export const lightAnsiTheme: ColorTheme = {
@@ -58,4 +60,5 @@ export const lightAnsiTheme: ColorTheme = {
   agent: { bg: "#5f5fff", fg: "#ffffff" },
   thinking: { bg: "#8700d7", fg: "#ffffff" },
   cacheTimer: { bg: "#00875f", fg: "#ffffff" },
+  outputStyle: { bg: "#008080", fg: "#ffffff" },
 };

--- a/src/themes/nord.ts
+++ b/src/themes/nord.ts
@@ -18,6 +18,7 @@ export const nordTheme: ColorTheme = {
   agent: { bg: "#4c566a", fg: "#b48ead" },
   thinking: { bg: "#3b4252", fg: "#b48ead" },
   cacheTimer: { bg: "#3b4252", fg: "#a3be8c" },
+  outputStyle: { bg: "#3b4252", fg: "#8fbcbb" },
 };
 
 export const nordAnsi256Theme: ColorTheme = {
@@ -38,6 +39,7 @@ export const nordAnsi256Theme: ColorTheme = {
   agent: { bg: "#6c6c6c", fg: "#d787af" },
   thinking: { bg: "#4e4e4e", fg: "#d787af" },
   cacheTimer: { bg: "#4e4e4e", fg: "#87af87" },
+  outputStyle: { bg: "#4e4e4e", fg: "#87d7d7" },
 };
 
 export const nordAnsiTheme: ColorTheme = {
@@ -58,4 +60,5 @@ export const nordAnsiTheme: ColorTheme = {
   agent: { bg: "#808080", fg: "#ff87af" },
   thinking: { bg: "#585858", fg: "#ff87d7" },
   cacheTimer: { bg: "#585858", fg: "#87d787" },
+  outputStyle: { bg: "#585858", fg: "#00d7d7" },
 };

--- a/src/themes/rose-pine.ts
+++ b/src/themes/rose-pine.ts
@@ -18,6 +18,7 @@ export const rosePineTheme: ColorTheme = {
   agent: { bg: "#2a273f", fg: "#c4a7e7" },
   thinking: { bg: "#26223a", fg: "#c4a7e7" },
   cacheTimer: { bg: "#1f2d2e", fg: "#9ccfd8" },
+  outputStyle: { bg: "#21313a", fg: "#9ccfd8" },
 };
 
 export const rosePineAnsi256Theme: ColorTheme = {
@@ -38,6 +39,7 @@ export const rosePineAnsi256Theme: ColorTheme = {
   agent: { bg: "#4e4e4e", fg: "#d787d7" },
   thinking: { bg: "#303030", fg: "#d787d7" },
   cacheTimer: { bg: "#303030", fg: "#87d7d7" },
+  outputStyle: { bg: "#303030", fg: "#87d7d7" },
 };
 
 export const rosePineAnsiTheme: ColorTheme = {
@@ -58,4 +60,5 @@ export const rosePineAnsiTheme: ColorTheme = {
   agent: { bg: "#666666", fg: "#ff87ff" },
   thinking: { bg: "#444444", fg: "#ff87ff" },
   cacheTimer: { bg: "#444444", fg: "#00d7d7" },
+  outputStyle: { bg: "#444444", fg: "#00d7d7" },
 };

--- a/src/themes/tokyo-night.ts
+++ b/src/themes/tokyo-night.ts
@@ -18,6 +18,7 @@ export const tokyoNightTheme: ColorTheme = {
   agent: { bg: "#2d2b55", fg: "#bb9af7" },
   thinking: { bg: "#2f2a3d", fg: "#bb9af7" },
   cacheTimer: { bg: "#1f2e2a", fg: "#9ece6a" },
+  outputStyle: { bg: "#2a3d3d", fg: "#73daca" },
 };
 
 export const tokyoNightAnsi256Theme: ColorTheme = {
@@ -38,6 +39,7 @@ export const tokyoNightAnsi256Theme: ColorTheme = {
   agent: { bg: "#5f5f87", fg: "#af87ff" },
   thinking: { bg: "#444460", fg: "#d787ff" },
   cacheTimer: { bg: "#1c3a30", fg: "#87d787" },
+  outputStyle: { bg: "#444460", fg: "#5fd7af" },
 };
 
 export const tokyoNightAnsiTheme: ColorTheme = {
@@ -58,4 +60,5 @@ export const tokyoNightAnsiTheme: ColorTheme = {
   agent: { bg: "#5f5faf", fg: "#d787ff" },
   thinking: { bg: "#585870", fg: "#d787ff" },
   cacheTimer: { bg: "#305050", fg: "#00d787" },
+  outputStyle: { bg: "#585870", fg: "#5fd7af" },
 };

--- a/src/tui/sections.ts
+++ b/src/tui/sections.ts
@@ -26,7 +26,10 @@ import {
   formatCacheTimerRemaining,
 } from "../utils/formatters";
 import { resolveBudgetDisplay } from "../utils/budget";
-import type { CacheTimerSegmentConfig } from "../segments/renderer";
+import type {
+  CacheTimerSegmentConfig,
+  OutputStyleSegmentConfig,
+} from "../segments/renderer";
 import { colorize, truncateAnsi } from "./primitives";
 import {
   getEffortLevel,
@@ -1010,7 +1013,7 @@ function formatAgentSegment(
 function formatOutputStyleParts(
   data: TuiData,
   sym: SymbolSet,
-  outputStyleConfig: { hideDefault?: boolean } | undefined,
+  outputStyleConfig: OutputStyleSegmentConfig | undefined,
   iconVisible = true,
 ): Record<string, string> {
   const name = getOutputStyleName(data.hookData);
@@ -1027,7 +1030,7 @@ function formatOutputStyleParts(
 function formatOutputStyleSegment(
   data: TuiData,
   sym: SymbolSet,
-  outputStyleConfig: { showLabel?: boolean; hideDefault?: boolean } | undefined,
+  outputStyleConfig: OutputStyleSegmentConfig | undefined,
   iconVisible = true,
 ): string {
   const parts = formatOutputStyleParts(
@@ -1051,11 +1054,14 @@ function formatOutputStyleSegment(
  */
 function getOutputStyleConfig(
   config: PowerlineConfig,
-): { showLabel?: boolean; hideDefault?: boolean } | undefined {
+): OutputStyleSegmentConfig | undefined {
   const configured = config.display.lines.map(
     (line) => line.segments.outputStyle,
   );
-  return configured.find((s) => s?.enabled) ?? configured.find((s) => s);
+  return (
+    configured.find((segment) => segment?.enabled) ??
+    configured.find((segment) => segment !== undefined)
+  );
 }
 
 function buildThinkingBody(

--- a/src/tui/sections.ts
+++ b/src/tui/sections.ts
@@ -28,7 +28,11 @@ import {
 import { resolveBudgetDisplay } from "../utils/budget";
 import type { CacheTimerSegmentConfig } from "../segments/renderer";
 import { colorize, truncateAnsi } from "./primitives";
-import { getEffortLevel, getThinkingEnabled } from "../utils/claude";
+import {
+  getEffortLevel,
+  getOutputStyleName,
+  getThinkingEnabled,
+} from "../utils/claude";
 import { resolveIconVisibility } from "../utils/icon-visibility";
 
 export function resolveTitleToken(
@@ -457,6 +461,28 @@ export function collectFooterParts(
         cacheTimerConfig,
       );
       parts.push(colorize(cacheTimerText, fg, reset, bold));
+    }
+  }
+
+  const outputStyleEnabled = config.display.lines.some(
+    (line) => line.segments.outputStyle?.enabled,
+  );
+  if (outputStyleEnabled) {
+    const outputStyleText = formatOutputStyleSegment(
+      data,
+      sym,
+      getOutputStyleConfig(config),
+      resolveIconVisibility(config, "outputStyle"),
+    );
+    if (outputStyleText) {
+      parts.push(
+        colorize(
+          outputStyleText,
+          colors.outputStyleFg,
+          reset,
+          colors.outputStyleBold,
+        ),
+      );
     }
   }
 
@@ -981,6 +1007,57 @@ function formatAgentSegment(
   return parts.icon ? `${parts.icon} ${body}` : body;
 }
 
+function formatOutputStyleParts(
+  data: TuiData,
+  sym: SymbolSet,
+  outputStyleConfig: { hideDefault?: boolean } | undefined,
+  iconVisible = true,
+): Record<string, string> {
+  const name = getOutputStyleName(data.hookData);
+  if (!name) return { icon: "", name: "" };
+  if (outputStyleConfig?.hideDefault && name.toLowerCase() === "default") {
+    return { icon: "", name: "" };
+  }
+  return {
+    icon: iconVisible ? sym.output_style : "",
+    name,
+  };
+}
+
+function formatOutputStyleSegment(
+  data: TuiData,
+  sym: SymbolSet,
+  outputStyleConfig: { showLabel?: boolean; hideDefault?: boolean } | undefined,
+  iconVisible = true,
+): string {
+  const parts = formatOutputStyleParts(
+    data,
+    sym,
+    outputStyleConfig,
+    iconVisible,
+  );
+  if (!parts.name) return "";
+  const body = outputStyleConfig?.showLabel
+    ? `style: ${parts.name}`
+    : parts.name;
+  return parts.icon ? `${parts.icon} ${body}` : body;
+}
+
+/**
+ * The enabled entry wins, so the hardcoded footer keeps the options of the
+ * line it renders. The fallback to any configured entry exists for grid mode,
+ * where cell placement decides visibility and `enabled` is often left false —
+ * without it, `showLabel` and `hideDefault` would be silently ignored there.
+ */
+function getOutputStyleConfig(
+  config: PowerlineConfig,
+): { showLabel?: boolean; hideDefault?: boolean } | undefined {
+  const configured = config.display.lines.map(
+    (line) => line.segments.outputStyle,
+  );
+  return configured.find((s) => s?.enabled) ?? configured.find((s) => s);
+}
+
 function buildThinkingBody(
   data: TuiData,
   thinkingConfig: { showEnabled?: boolean; showEffort?: boolean } | undefined,
@@ -1237,6 +1314,7 @@ export function resolveSegments(
     agent: resolveIconVisibility(config, "agent"),
     thinking: resolveIconVisibility(config, "thinking"),
     cacheTimer: resolveIconVisibility(config, "cacheTimer"),
+    outputStyle: resolveIconVisibility(config, "outputStyle"),
   };
 
   // Model
@@ -1544,6 +1622,34 @@ export function resolveSegments(
     reset,
     pf,
     cacheTimerStyleResolved.bold,
+  );
+
+  // Output style
+  const outputStyleSegConfig = getOutputStyleConfig(config);
+  const outputStyleColor = pf?.["outputStyle"] ?? colors.outputStyleFg;
+  result.outputStyle = colorizeOrEmpty(
+    formatOutputStyleSegment(
+      data,
+      sym,
+      outputStyleSegConfig,
+      iconVisible.outputStyle,
+    ),
+    outputStyleColor,
+    colors.outputStyleBold,
+  );
+  addParts(
+    result,
+    "outputStyle",
+    formatOutputStyleParts(
+      data,
+      sym,
+      outputStyleSegConfig,
+      iconVisible.outputStyle,
+    ),
+    colors.outputStyleFg,
+    reset,
+    pf,
+    colors.outputStyleBold,
   );
 
   // Apply segment templates: resolve items and compose default value

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -56,6 +56,7 @@ const SEGMENT_NAME_LIST = [
   "agent",
   "thinking",
   "cacheTimer",
+  "outputStyle",
 ] as const;
 
 export type SegmentName = (typeof SEGMENT_NAME_LIST)[number];
@@ -111,6 +112,7 @@ export const SEGMENT_PARTS: Record<SegmentName, readonly string[]> = {
   agent: ["icon", "name"],
   thinking: ["icon", "enabled", "effort"],
   cacheTimer: ["icon", "value"],
+  outputStyle: ["icon", "name"],
 } as const;
 
 export function isValidSegmentRef(name: string): boolean {

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -84,6 +84,13 @@ export function getThinkingEnabled(hookData: ClaudeHookData): boolean | null {
   return enabled;
 }
 
+export function getOutputStyleName(hookData: ClaudeHookData): string | null {
+  const name = hookData.output_style?.name;
+  if (typeof name !== "string") return null;
+  const trimmed = name.trim();
+  return trimmed ? trimmed : null;
+}
+
 export function getClaudePaths(): string[] {
   const paths: string[] = [];
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -39,6 +39,7 @@ export const SYMBOLS = {
   agent: "◇",
   thinking: "✦",
   cache_timer: "◴",
+  output_style: "✎",
 } as const;
 
 export const BOX_CHARS = {
@@ -179,4 +180,5 @@ export const TEXT_SYMBOLS = {
   agent: "&",
   thinking: "T",
   cache_timer: "C!",
+  output_style: "OS",
 } as const;

--- a/test/claude-utils.test.ts
+++ b/test/claude-utils.test.ts
@@ -1,8 +1,61 @@
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { findAgentTranscripts, collectProjectFiles } from "../src/utils/claude";
+import {
+  findAgentTranscripts,
+  collectProjectFiles,
+  getOutputStyleName,
+  type ClaudeHookData,
+} from "../src/utils/claude";
 import { CacheManager } from "../src/utils/cache";
+
+describe("getOutputStyleName", () => {
+  const base = {
+    hook_event_name: "Status",
+    session_id: "test",
+    transcript_path: "/tmp/test.jsonl",
+    cwd: "/test",
+    model: { id: "claude-sonnet-4-6", display_name: "Sonnet" },
+    workspace: { current_dir: "/test", project_dir: "/test" },
+  } as ClaudeHookData;
+
+  const withStyle = (name: unknown): ClaudeHookData =>
+    ({ ...base, output_style: { name } }) as ClaudeHookData;
+
+  it("returns the name when output_style.name is a non-empty string", () => {
+    expect(getOutputStyleName(withStyle("Explanatory"))).toBe("Explanatory");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(getOutputStyleName(withStyle("  Explanatory  "))).toBe(
+      "Explanatory",
+    );
+  });
+
+  it("returns null for a whitespace-only name", () => {
+    expect(getOutputStyleName(withStyle("   "))).toBeNull();
+  });
+
+  it("returns null for an empty name", () => {
+    expect(getOutputStyleName(withStyle(""))).toBeNull();
+  });
+
+  it("returns null for a non-string name", () => {
+    expect(getOutputStyleName(withStyle(42))).toBeNull();
+    expect(getOutputStyleName(withStyle(null))).toBeNull();
+    expect(getOutputStyleName(withStyle(undefined))).toBeNull();
+  });
+
+  it("returns null when output_style is absent", () => {
+    expect(getOutputStyleName(base)).toBeNull();
+  });
+
+  it("preserves internal spaces and punctuation verbatim", () => {
+    expect(getOutputStyleName(withStyle("My Custom Style (v2)"))).toBe(
+      "My Custom Style (v2)",
+    );
+  });
+});
 
 describe("findAgentTranscripts", () => {
   let tempDir: string;

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -5,7 +5,7 @@ import {
   extractBgToFg,
 } from "../src/utils/colors";
 import { getColorSupport } from "../src/utils/color-support";
-import { getTheme } from "../src/themes";
+import { getTheme, BUILT_IN_THEMES } from "../src/themes";
 
 describe("Colors", () => {
   describe("Core Color Functions", () => {
@@ -130,6 +130,20 @@ describe("Colors", () => {
 
       const noneTheme = getTheme("nord", "none");
       expect(noneTheme?.directory.bg).toBe(ansiTheme?.directory.bg);
+    });
+  });
+
+  describe("Built-in theme completeness", () => {
+    it("should define outputStyle colors in every built-in theme variant", () => {
+      const names = Object.keys(BUILT_IN_THEMES);
+      expect(names).toHaveLength(18);
+
+      for (const name of names) {
+        const theme = BUILT_IN_THEMES[name]!;
+        expect(theme.outputStyle).toBeDefined();
+        expect(theme.outputStyle.bg).toMatch(/^#[0-9a-fA-F]{6}$/);
+        expect(theme.outputStyle.fg).toMatch(/^#[0-9a-fA-F]{6}$/);
+      }
     });
   });
 });

--- a/test/colors.test.ts
+++ b/test/colors.test.ts
@@ -136,11 +136,10 @@ describe("Colors", () => {
   describe("Built-in theme completeness", () => {
     it("should define outputStyle colors in every built-in theme variant", () => {
       const names = Object.keys(BUILT_IN_THEMES);
-      expect(names).toHaveLength(18);
+      expect(names.length).toBeGreaterThan(0);
 
       for (const name of names) {
         const theme = BUILT_IN_THEMES[name]!;
-        expect(theme.outputStyle).toBeDefined();
         expect(theme.outputStyle.bg).toMatch(/^#[0-9a-fA-F]{6}$/);
         expect(theme.outputStyle.fg).toMatch(/^#[0-9a-fA-F]{6}$/);
       }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -24,6 +24,16 @@ describe("config", () => {
       expect(DEFAULT_CONFIG.display.style).toBe("minimal");
       expect(DEFAULT_CONFIG.budget?.session).toBeDefined();
     });
+
+    it("should ship outputStyle disabled with both options off", () => {
+      expect(
+        DEFAULT_CONFIG.display.lines[0]?.segments.outputStyle,
+      ).toEqual({
+        enabled: false,
+        showLabel: false,
+        hideDefault: false,
+      });
+    });
   });
 
   describe("loadConfig", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -26,9 +26,7 @@ describe("config", () => {
     });
 
     it("should ship outputStyle disabled with both options off", () => {
-      expect(
-        DEFAULT_CONFIG.display.lines[0]?.segments.outputStyle,
-      ).toEqual({
+      expect(DEFAULT_CONFIG.display.lines[0]?.segments.outputStyle).toEqual({
         enabled: false,
         showLabel: false,
         hideDefault: false,

--- a/test/grid.test.ts
+++ b/test/grid.test.ts
@@ -685,6 +685,13 @@ describe("isValidSegmentRef", () => {
     expect(isValidSegmentRef("version.value")).toBe(true);
   });
 
+  it("should accept outputStyle and its parts", () => {
+    expect(isValidSegmentRef("outputStyle")).toBe(true);
+    expect(isValidSegmentRef("outputStyle.icon")).toBe(true);
+    expect(isValidSegmentRef("outputStyle.name")).toBe(true);
+    expect(isValidSegmentRef("outputStyle.notapart")).toBe(false);
+  });
+
   it("should reject invalid segment names", () => {
     expect(isValidSegmentRef("notasegment")).toBe(false);
     expect(isValidSegmentRef("session.notapart")).toBe(false);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,5 +1,8 @@
 import { PowerlineRenderer } from "../src/powerline";
 import type { ClaudeHookData } from "../src/utils/claude";
+import type { PowerlineConfig } from "../src/config/loader";
+import type { OutputStyleSegmentConfig } from "../src/segments/renderer";
+import { stripAnsi } from "../src/utils/terminal";
 
 jest.mock("../src/segments/session", () => ({
   SessionProvider: jest.fn().mockImplementation(() => ({
@@ -145,5 +148,82 @@ describe("Integration Tests", () => {
     const result = await renderer.generateStatusline(mockHookData);
 
     expect(typeof result).toBe("string");
+  });
+
+  describe("outputStyle segment end to end", () => {
+    const styleHookData: ClaudeHookData = {
+      ...mockHookData,
+      output_style: { name: "Explanatory" },
+    };
+
+    const configFor = (
+      display: Partial<PowerlineConfig["display"]> = {},
+      segment: OutputStyleSegmentConfig = { enabled: true },
+    ): PowerlineConfig => ({
+      theme: "dark",
+      display: {
+        colorCompatibility: "truecolor",
+        autoWrap: false,
+        ...display,
+        lines: [{ segments: { outputStyle: segment } }],
+      },
+    });
+
+    it.each(["minimal", "powerline", "capsule"] as const)(
+      "renders the style name in %s display style",
+      async (style) => {
+        const result = await new PowerlineRenderer(
+          configFor({ style }),
+        ).generateStatusline(styleHookData);
+        expect(stripAnsi(result)).toContain("✎ Explanatory");
+      },
+    );
+
+    it("renders the text-charset fallback OS instead of the pencil glyph", async () => {
+      const result = await new PowerlineRenderer(
+        configFor({ style: "minimal", charset: "text" }),
+      ).generateStatusline(styleHookData);
+      expect(stripAnsi(result)).toContain("OS Explanatory");
+      expect(result).not.toContain("✎");
+    });
+
+    it("renders the bare name when display.showIcons is false", async () => {
+      const result = await new PowerlineRenderer(
+        configFor({ style: "minimal", showIcons: false }),
+      ).generateStatusline(styleHookData);
+      expect(stripAnsi(result)).toContain("Explanatory");
+      expect(result).not.toContain("✎");
+    });
+
+    it("renders the label form when showLabel is set", async () => {
+      const result = await new PowerlineRenderer(
+        configFor({ style: "minimal" }, { enabled: true, showLabel: true }),
+      ).generateStatusline(styleHookData);
+      expect(stripAnsi(result)).toContain("✎ style: Explanatory");
+    });
+
+    it("omits the segment when hideDefault is set and the style is default", async () => {
+      const defaultHookData: ClaudeHookData = {
+        ...mockHookData,
+        output_style: { name: "default" },
+      };
+
+      const hidden = await new PowerlineRenderer(
+        configFor({ style: "minimal" }, { enabled: true, hideDefault: true }),
+      ).generateStatusline(defaultHookData);
+      expect(stripAnsi(hidden)).not.toContain("default");
+
+      const shown = await new PowerlineRenderer(
+        configFor({ style: "minimal" }, { enabled: true, hideDefault: false }),
+      ).generateStatusline(defaultHookData);
+      expect(stripAnsi(shown)).toContain("✎ default");
+    });
+
+    it("omits the segment when Claude Code sends no output_style", async () => {
+      const result = await new PowerlineRenderer(
+        configFor({ style: "minimal" }),
+      ).generateStatusline(mockHookData);
+      expect(result).not.toContain("✎");
+    });
   });
 });

--- a/test/segments.test.ts
+++ b/test/segments.test.ts
@@ -27,6 +27,12 @@ jest.mock("../src/utils/claude", () => ({
     if (typeof enabled !== "boolean") return null;
     return enabled;
   },
+  getOutputStyleName: (hookData: any) => {
+    const name = hookData?.output_style?.name;
+    if (typeof name !== "string") return null;
+    const trimmed = name.trim();
+    return trimmed ? trimmed : null;
+  },
 }));
 
 const mockLoadEntries = loadEntriesFromProjects as jest.MockedFunction<
@@ -444,6 +450,125 @@ describe("Segment Time Logic", () => {
         expect(result!.bgColor).toBe(colors.thinkingBg);
         expect(result!.fgColor).toBe(colors.thinkingFg);
       }
+    });
+  });
+
+  describe("Output Style Segment", () => {
+    const config = { theme: "dark", display: { style: "minimal" } } as any;
+    const symbols = { output_style: "✎" } as any;
+    const colors = {
+      outputStyleBg: "#1f3a3a",
+      outputStyleFg: "#7fd1c4",
+    } as any;
+
+    const base: ClaudeHookData = {
+      hook_event_name: "Status",
+      session_id: "test",
+      transcript_path: "/tmp/test.json",
+      cwd: "/test",
+      model: { id: "claude-sonnet-4-6", display_name: "Sonnet" },
+      workspace: { current_dir: "/test", project_dir: "/test" },
+    };
+
+    type Case = {
+      name: string;
+      hook: Partial<ClaudeHookData>;
+      cfg: { showIcon?: boolean; showLabel?: boolean; hideDefault?: boolean };
+      expected: string | null;
+    };
+
+    const cases: Case[] = [
+      {
+        name: "name present, no options -> icon and bare name",
+        hook: { output_style: { name: "Explanatory" } },
+        cfg: {},
+        expected: "✎ Explanatory",
+      },
+      {
+        name: "showLabel -> 'style: ' prefix before the name",
+        hook: { output_style: { name: "Explanatory" } },
+        cfg: { showLabel: true },
+        expected: "✎ style: Explanatory",
+      },
+      {
+        name: "showIcon false -> bare name with no leading space",
+        hook: { output_style: { name: "Explanatory" } },
+        cfg: { showIcon: false },
+        expected: "Explanatory",
+      },
+      {
+        name: "hideDefault with lowercase 'default' -> null",
+        hook: { output_style: { name: "default" } },
+        cfg: { hideDefault: true },
+        expected: null,
+      },
+      {
+        name: "hideDefault with capitalised 'Default' -> null (case-insensitive)",
+        hook: { output_style: { name: "Default" } },
+        cfg: { hideDefault: true },
+        expected: null,
+      },
+      {
+        name: "hideDefault false with 'default' -> renders the name",
+        hook: { output_style: { name: "default" } },
+        cfg: { hideDefault: false },
+        expected: "✎ default",
+      },
+      {
+        name: "output_style absent -> null",
+        hook: {},
+        cfg: {},
+        expected: null,
+      },
+      {
+        name: "whitespace-only name -> null",
+        hook: { output_style: { name: "   " } },
+        cfg: {},
+        expected: null,
+      },
+    ];
+
+    it.each(cases)("$name", ({ hook, cfg, expected }) => {
+      const renderer = new SegmentRenderer(config, symbols);
+      const result = renderer.renderOutputStyle(
+        { ...base, ...hook } as ClaudeHookData,
+        colors,
+        { enabled: true, ...cfg },
+      );
+      if (expected === null) {
+        expect(result).toBeNull();
+      } else {
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe(expected);
+        expect(result!.bgColor).toBe(colors.outputStyleBg);
+        expect(result!.fgColor).toBe(colors.outputStyleFg);
+      }
+    });
+
+    it("hides the icon when display.showIcons is false globally", () => {
+      const renderer = new SegmentRenderer(
+        {
+          theme: "dark",
+          display: { style: "minimal", showIcons: false },
+        } as any,
+        symbols,
+      );
+      const result = renderer.renderOutputStyle(
+        { ...base, output_style: { name: "Explanatory" } } as ClaudeHookData,
+        colors,
+        { enabled: true },
+      );
+      expect(result!.text).toBe("Explanatory");
+    });
+
+    it("renders a non-string name as absent", () => {
+      const renderer = new SegmentRenderer(config, symbols);
+      const result = renderer.renderOutputStyle(
+        { ...base, output_style: { name: 7 } } as any,
+        colors,
+        { enabled: true },
+      );
+      expect(result).toBeNull();
     });
   });
 

--- a/test/segments.test.ts
+++ b/test/segments.test.ts
@@ -520,12 +520,6 @@ describe("Segment Time Logic", () => {
         cfg: {},
         expected: null,
       },
-      {
-        name: "whitespace-only name -> null",
-        hook: { output_style: { name: "   " } },
-        cfg: {},
-        expected: null,
-      },
     ];
 
     it.each(cases)("$name", ({ hook, cfg, expected }) => {
@@ -559,16 +553,6 @@ describe("Segment Time Logic", () => {
         { enabled: true },
       );
       expect(result!.text).toBe("Explanatory");
-    });
-
-    it("renders a non-string name as absent", () => {
-      const renderer = new SegmentRenderer(config, symbols);
-      const result = renderer.renderOutputStyle(
-        { ...base, output_style: { name: 7 } } as any,
-        colors,
-        { enabled: true },
-      );
-      expect(result).toBeNull();
     });
   });
 

--- a/test/theme-bold.test.ts
+++ b/test/theme-bold.test.ts
@@ -36,6 +36,7 @@ function makeCustomTheme(overrides: Partial<ColorTheme> = {}): ColorTheme {
     agent: { ...base },
     thinking: { ...base },
     cacheTimer: { ...base },
+    outputStyle: { ...base },
     ...overrides,
   };
 }
@@ -103,6 +104,42 @@ describe("segment bold theme", () => {
     ).generateStatusline(mockHookData);
     expect(tuiPlainOut).not.toContain("\x1b[1m");
     expect(tuiPlainOut).not.toContain("\x1b[22m");
+  });
+
+  it("applies outputStyle bold from a custom theme through getSegmentBoldFlag", async () => {
+    const makeOutputStyleConfig = (custom: ColorTheme): PowerlineConfig => ({
+      ...makeConfig(custom),
+      display: {
+        ...makeConfig(custom).display,
+        lines: [
+          {
+            segments: {
+              outputStyle: { enabled: true },
+            },
+          },
+        ],
+      },
+    });
+
+    const hookData = { ...mockHookData, output_style: { name: "Explanatory" } };
+
+    const boldOut = await new PowerlineRenderer(
+      makeOutputStyleConfig(
+        makeCustomTheme({
+          outputStyle: { bg: "#1f3a3a", fg: "#7fd1c4", bold: true },
+        }),
+      ),
+    ).generateStatusline(hookData);
+    expect(stripAnsi(boldOut)).toContain("✎ Explanatory");
+    expect(boldOut).toContain("\x1b[1m");
+    expect(boldOut).toContain("\x1b[22m");
+
+    const plainOut = await new PowerlineRenderer(
+      makeOutputStyleConfig(makeCustomTheme()),
+    ).generateStatusline(hookData);
+    expect(stripAnsi(plainOut)).toContain("✎ Explanatory");
+    expect(plainOut).not.toContain("\x1b[1m");
+    expect(plainOut).not.toContain("\x1b[22m");
   });
 
   it("preserves visible width — bold SGRs do not affect visibleLength / stripAnsi", () => {

--- a/test/theme-bold.test.ts
+++ b/test/theme-bold.test.ts
@@ -107,19 +107,22 @@ describe("segment bold theme", () => {
   });
 
   it("applies outputStyle bold from a custom theme through getSegmentBoldFlag", async () => {
-    const makeOutputStyleConfig = (custom: ColorTheme): PowerlineConfig => ({
-      ...makeConfig(custom),
-      display: {
-        ...makeConfig(custom).display,
-        lines: [
-          {
-            segments: {
-              outputStyle: { enabled: true },
+    const makeOutputStyleConfig = (custom: ColorTheme): PowerlineConfig => {
+      const base = makeConfig(custom);
+      return {
+        ...base,
+        display: {
+          ...base.display,
+          lines: [
+            {
+              segments: {
+                outputStyle: { enabled: true },
+              },
             },
-          },
-        ],
-      },
-    });
+          ],
+        },
+      };
+    };
 
     const hookData = { ...mockHookData, output_style: { name: "Explanatory" } };
 

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -613,109 +613,65 @@ describe("TUI Panel Rendering", () => {
       expect(resultAbsent["outputStyle.name"]).toBe("");
     });
 
-    it("resolveSegments honors outputStyle showLabel and hideDefault", () => {
-      const configWith = (
-        segment: OutputStyleSegmentConfig,
-      ): PowerlineConfig => ({
-        ...DEFAULT_CONFIG,
-        display: {
-          ...DEFAULT_CONFIG.display,
-          style: "tui",
-          lines: [
-            {
-              segments: {
-                ...DEFAULT_CONFIG.display.lines[0]!.segments,
-                outputStyle: segment,
+    it.each([true, false])(
+      "resolveSegments honors outputStyle showLabel and hideDefault whether enabled is %s, because grid cell placement controls visibility",
+      (enabled) => {
+        const configWith = (
+          segment: OutputStyleSegmentConfig,
+        ): PowerlineConfig => ({
+          ...DEFAULT_CONFIG,
+          display: {
+            ...DEFAULT_CONFIG.display,
+            style: "tui",
+            lines: [
+              {
+                segments: {
+                  ...DEFAULT_CONFIG.display.lines[0]!.segments,
+                  outputStyle: segment,
+                },
               },
-            },
-          ],
-        },
-      });
+            ],
+          },
+        });
 
-      const labelled = makeTuiData({
-        hookData: {
-          ...makeTuiData().hookData,
-          output_style: { name: "Explanatory" },
-        },
-      });
-      const { data: labelledResult } = resolveSegments(
-        labelled,
-        mkCtx(configWith({ enabled: true, showLabel: true }), labelled),
-      );
-      expect(labelledResult["outputStyle"]).toBe(
-        `${SYMBOLS.output_style} style: Explanatory`,
-      );
-      expect(labelledResult["outputStyle.name"]).toBe("Explanatory");
+        const labelled = makeTuiData({
+          hookData: {
+            ...makeTuiData().hookData,
+            output_style: { name: "Explanatory" },
+          },
+        });
+        const { data: labelledResult } = resolveSegments(
+          labelled,
+          mkCtx(configWith({ enabled, showLabel: true }), labelled),
+        );
+        expect(labelledResult["outputStyle"]).toBe(
+          `${SYMBOLS.output_style} style: Explanatory`,
+        );
+        expect(labelledResult["outputStyle.name"]).toBe("Explanatory");
 
-      const defaultStyle = makeTuiData({
-        hookData: {
-          ...makeTuiData().hookData,
-          output_style: { name: "Default" },
-        },
-      });
-      const { data: hiddenResult } = resolveSegments(
-        defaultStyle,
-        mkCtx(configWith({ enabled: true, hideDefault: true }), defaultStyle),
-      );
-      expect(hiddenResult["outputStyle"]).toBe("");
-      expect(hiddenResult["outputStyle.icon"]).toBe("");
-      expect(hiddenResult["outputStyle.name"]).toBe("");
-    });
-
-    it("applies outputStyle options in grid mode even when enabled is false, since cell placement controls visibility there", () => {
-      const configWith = (
-        segment: OutputStyleSegmentConfig,
-      ): PowerlineConfig => ({
-        ...DEFAULT_CONFIG,
-        display: {
-          ...DEFAULT_CONFIG.display,
-          style: "tui",
-          lines: [
-            {
-              segments: {
-                ...DEFAULT_CONFIG.display.lines[0]!.segments,
-                outputStyle: segment,
-              },
-            },
-          ],
-        },
-      });
-
-      const labelled = makeTuiData({
-        hookData: {
-          ...makeTuiData().hookData,
-          output_style: { name: "Explanatory" },
-        },
-      });
-      const { data: labelledResult } = resolveSegments(
-        labelled,
-        mkCtx(configWith({ enabled: false, showLabel: true }), labelled),
-      );
-      expect(labelledResult["outputStyle"]).toBe(
-        `${SYMBOLS.output_style} style: Explanatory`,
-      );
-
-      const defaultStyle = makeTuiData({
-        hookData: {
-          ...makeTuiData().hookData,
-          output_style: { name: "default" },
-        },
-      });
-      const { data: hiddenResult } = resolveSegments(
-        defaultStyle,
-        mkCtx(configWith({ enabled: false, hideDefault: true }), defaultStyle),
-      );
-      expect(hiddenResult["outputStyle"]).toBe("");
-      expect(hiddenResult["outputStyle.name"]).toBe("");
-    });
+        const defaultStyle = makeTuiData({
+          hookData: {
+            ...makeTuiData().hookData,
+            output_style: { name: "Default" },
+          },
+        });
+        const { data: hiddenResult } = resolveSegments(
+          defaultStyle,
+          mkCtx(configWith({ enabled, hideDefault: true }), defaultStyle),
+        );
+        expect(hiddenResult["outputStyle"]).toBe("");
+        expect(hiddenResult["outputStyle.icon"]).toBe("");
+        expect(hiddenResult["outputStyle.name"]).toBe("");
+      },
+    );
   });
 
   describe("outputStyle in the TUI panel", () => {
-    const styleData = () =>
+    const styleData = (name = "Explanatory") =>
       makeTuiData({
         hookData: {
           ...makeTuiData().hookData,
-          output_style: { name: "Explanatory" },
+          output_style: { name },
         },
       });
 
@@ -761,14 +717,8 @@ describe("TUI Panel Rendering", () => {
     });
 
     it("omits the footer entry when hideDefault is set and the style is default", async () => {
-      const defaultData = makeTuiData({
-        hookData: {
-          ...makeTuiData().hookData,
-          output_style: { name: "default" },
-        },
-      });
       const result = await renderTuiPanel(
-        defaultData,
+        styleData("default"),
         BOX_CHARS,
         "",
         100,

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -7,6 +7,7 @@ import {
 import type { TuiData, BoxChars, RenderCtx } from "../src/tui/types";
 import type { PowerlineColors } from "../src/themes";
 import type { PowerlineConfig } from "../src/config/loader";
+import type { OutputStyleSegmentConfig } from "../src/segments/renderer";
 import { BOX_CHARS, SYMBOLS } from "../src/utils/constants";
 import { DEFAULT_CONFIG } from "../src/config/defaults";
 
@@ -64,6 +65,9 @@ const PLAIN_COLORS: PowerlineColors = {
   cacheTimerBg: "",
   cacheTimerFg: "",
   cacheTimerBold: false,
+  outputStyleBg: "",
+  outputStyleFg: "",
+  outputStyleBold: false,
   partFg: {},
 };
 
@@ -575,6 +579,236 @@ describe("TUI Panel Rendering", () => {
       expect(result["cacheTimer.icon"]).toBe(SYMBOLS.cache_timer);
       expect(result["cacheTimer.value"]).toBe("59:50");
       expect(result["cacheTimer"]).toContain("59:50");
+    });
+
+    it("resolveSegments exposes outputStyle sub-parts (icon, name) when data present, empty when absent", () => {
+      const config: PowerlineConfig = {
+        ...DEFAULT_CONFIG,
+        display: { ...DEFAULT_CONFIG.display, style: "tui" },
+      };
+
+      const withData = makeTuiData({
+        hookData: {
+          ...makeTuiData().hookData,
+          output_style: { name: "Explanatory" },
+        },
+      });
+      const { data: resultPresent } = resolveSegments(
+        withData,
+        mkCtx(config, withData),
+      );
+      expect(resultPresent["outputStyle.icon"]).toBe(SYMBOLS.output_style);
+      expect(resultPresent["outputStyle.name"]).toBe("Explanatory");
+      expect(resultPresent["outputStyle"]).toBe(
+        `${SYMBOLS.output_style} Explanatory`,
+      );
+
+      const absent = makeTuiData();
+      const { data: resultAbsent } = resolveSegments(
+        absent,
+        mkCtx(config, absent),
+      );
+      expect(resultAbsent["outputStyle"]).toBe("");
+      expect(resultAbsent["outputStyle.icon"]).toBe("");
+      expect(resultAbsent["outputStyle.name"]).toBe("");
+    });
+
+    it("resolveSegments honors outputStyle showLabel and hideDefault", () => {
+      const configWith = (
+        segment: OutputStyleSegmentConfig,
+      ): PowerlineConfig => ({
+        ...DEFAULT_CONFIG,
+        display: {
+          ...DEFAULT_CONFIG.display,
+          style: "tui",
+          lines: [
+            {
+              segments: {
+                ...DEFAULT_CONFIG.display.lines[0]!.segments,
+                outputStyle: segment,
+              },
+            },
+          ],
+        },
+      });
+
+      const labelled = makeTuiData({
+        hookData: {
+          ...makeTuiData().hookData,
+          output_style: { name: "Explanatory" },
+        },
+      });
+      const { data: labelledResult } = resolveSegments(
+        labelled,
+        mkCtx(configWith({ enabled: true, showLabel: true }), labelled),
+      );
+      expect(labelledResult["outputStyle"]).toBe(
+        `${SYMBOLS.output_style} style: Explanatory`,
+      );
+      expect(labelledResult["outputStyle.name"]).toBe("Explanatory");
+
+      const defaultStyle = makeTuiData({
+        hookData: {
+          ...makeTuiData().hookData,
+          output_style: { name: "Default" },
+        },
+      });
+      const { data: hiddenResult } = resolveSegments(
+        defaultStyle,
+        mkCtx(configWith({ enabled: true, hideDefault: true }), defaultStyle),
+      );
+      expect(hiddenResult["outputStyle"]).toBe("");
+      expect(hiddenResult["outputStyle.icon"]).toBe("");
+      expect(hiddenResult["outputStyle.name"]).toBe("");
+    });
+
+    it("applies outputStyle options in grid mode even when enabled is false, since cell placement controls visibility there", () => {
+      const configWith = (
+        segment: OutputStyleSegmentConfig,
+      ): PowerlineConfig => ({
+        ...DEFAULT_CONFIG,
+        display: {
+          ...DEFAULT_CONFIG.display,
+          style: "tui",
+          lines: [
+            {
+              segments: {
+                ...DEFAULT_CONFIG.display.lines[0]!.segments,
+                outputStyle: segment,
+              },
+            },
+          ],
+        },
+      });
+
+      const labelled = makeTuiData({
+        hookData: {
+          ...makeTuiData().hookData,
+          output_style: { name: "Explanatory" },
+        },
+      });
+      const { data: labelledResult } = resolveSegments(
+        labelled,
+        mkCtx(configWith({ enabled: false, showLabel: true }), labelled),
+      );
+      expect(labelledResult["outputStyle"]).toBe(
+        `${SYMBOLS.output_style} style: Explanatory`,
+      );
+
+      const defaultStyle = makeTuiData({
+        hookData: {
+          ...makeTuiData().hookData,
+          output_style: { name: "default" },
+        },
+      });
+      const { data: hiddenResult } = resolveSegments(
+        defaultStyle,
+        mkCtx(configWith({ enabled: false, hideDefault: true }), defaultStyle),
+      );
+      expect(hiddenResult["outputStyle"]).toBe("");
+      expect(hiddenResult["outputStyle.name"]).toBe("");
+    });
+  });
+
+  describe("outputStyle in the TUI panel", () => {
+    const styleData = () =>
+      makeTuiData({
+        hookData: {
+          ...makeTuiData().hookData,
+          output_style: { name: "Explanatory" },
+        },
+      });
+
+    const footerConfig = (
+      segment?: OutputStyleSegmentConfig,
+    ): PowerlineConfig => ({
+      ...DEFAULT_CONFIG,
+      display: {
+        ...DEFAULT_CONFIG.display,
+        style: "tui",
+        lines: [
+          {
+            segments: {
+              ...DEFAULT_CONFIG.display.lines[0]!.segments,
+              ...(segment ? { outputStyle: segment } : {}),
+            },
+          },
+        ],
+      },
+    });
+
+    it("omits the footer entry when the segment is disabled in config", async () => {
+      const result = await renderTuiPanel(
+        styleData(),
+        BOX_CHARS,
+        "",
+        100,
+        footerConfig({ enabled: false }),
+      );
+      expect(result).not.toContain("Explanatory");
+      expect(result).not.toContain(SYMBOLS.output_style);
+    });
+
+    it("shows the footer entry when the segment is enabled in config", async () => {
+      const result = await renderTuiPanel(
+        styleData(),
+        BOX_CHARS,
+        "",
+        100,
+        footerConfig({ enabled: true }),
+      );
+      expect(result).toContain(`${SYMBOLS.output_style} Explanatory`);
+    });
+
+    it("omits the footer entry when hideDefault is set and the style is default", async () => {
+      const defaultData = makeTuiData({
+        hookData: {
+          ...makeTuiData().hookData,
+          output_style: { name: "default" },
+        },
+      });
+      const result = await renderTuiPanel(
+        defaultData,
+        BOX_CHARS,
+        "",
+        100,
+        footerConfig({ enabled: true, hideDefault: true }),
+      );
+      expect(result).not.toContain("default");
+      expect(result).not.toContain(SYMBOLS.output_style);
+    });
+
+    it("renders outputStyle.icon and outputStyle.name placed in grid cells", async () => {
+      const gridConfig: PowerlineConfig = {
+        ...DEFAULT_CONFIG,
+        display: {
+          ...DEFAULT_CONFIG.display,
+          style: "tui",
+          tui: {
+            widthReserve: 0,
+            terminalWidth: 100,
+            separator: { column: "  " },
+            breakpoints: [
+              {
+                minWidth: 0,
+                areas: ["outputStyle.icon outputStyle.name"],
+                columns: ["auto", "1fr"],
+                align: ["left", "left"],
+              },
+            ],
+          },
+        },
+      };
+
+      const result = await renderTuiPanel(
+        styleData(),
+        BOX_CHARS,
+        "",
+        100,
+        gridConfig,
+      );
+      expect(result).toContain(SYMBOLS.output_style);
+      expect(result).toContain("Explanatory");
     });
   });
 


### PR DESCRIPTION
Adds an opt-in `outputStyle` segment that shows the current output style. Claude Code already sends it on stdin as `output_style.name`, we just never read it.

Shows up as `✎ Explanatory` (or `OS Explanatory` with `charset: "text"`).

Options:
- `showLabel`: renders `style: Explanatory` instead of just the name
- `hideDefault`: hides the segment while the style is `default`

Both are off by default, and the segment itself is disabled by default. Works in minimal, powerline, capsule, and TUI (footer and grid cells). All six built-in themes got colors for it. If stdin has no `output_style` (older Claude Code versions), the segment just doesn't render.

Tests and README are updated. I'll follow up with a powerline-studio PR once this ships to npm.