### PR TITLE
fix(context): use Claude Code's context_window_size when current_usage is absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,14 @@ The two upstream options are independent. `showUpstream` controls the branch nam
 
 #### Model Context Limits
 
-Configure context window limits for different model types. Defaults to 200K tokens for all models.
+**You normally don't need this.** Claude Code 2.0.65+ reports the real context window
+in its status line data (`context_window.context_window_size`), and that value is used
+automatically. It already accounts for 1M-context models, the `[1m]` model suffix, the
+1M beta header, plan entitlements, and `CLAUDE_CODE_MAX_CONTEXT_TOKENS` — none of which
+can be inferred from the model name.
+
+`modelContextLimits` is only consulted when Claude Code reports no context window data
+at all, i.e. on versions older than 2.0.65.
 
 ```json
 "modelContextLimits": {
@@ -290,8 +297,6 @@ Configure context window limits for different model types. Defaults to 200K toke
 - `sonnet`: Claude Sonnet models (3.5, 4, etc.)
 - `opus`: Claude Opus models
 - `default`: Fallback for unrecognized models (200K)
-
-**Note:** Sonnet 4's 1M context window is currently in beta for tier 4+ users. Set `"sonnet": 1000000` when you have access.
 
 </details>
 

--- a/src/segments/context.ts
+++ b/src/segments/context.ts
@@ -129,11 +129,17 @@ export class ContextProvider {
   /**
    * Calculate context tokens by parsing the transcript file (fallback).
    * Used for older Claude Code versions that don't provide context_window.
+   *
+   * `nativeContextLimit` is Claude Code's own context_window_size when it is
+   * available. It is present even when current_usage is null (no messages
+   * yet), and it resolves 1M variants, plan caps and CLAUDE_CODE_MAX_CONTEXT_TOKENS,
+   * so it always beats inferring a limit from the model id.
    */
   async calculateContextTokensFromTranscript(
     transcriptPath: string,
     modelId?: string,
     autocompactBuffer: number = 33000,
+    nativeContextLimit?: number,
   ): Promise<ContextInfo | null> {
     try {
       debug(`Calculating context tokens from transcript: ${transcriptPath}`);
@@ -168,7 +174,9 @@ export class ContextProvider {
           (usage.cache_read_input_tokens || 0) +
           (usage.cache_creation_input_tokens || 0);
 
-        const contextLimit = modelId ? this.getContextLimit(modelId) : 200000;
+        const contextLimit =
+          nativeContextLimit ??
+          (modelId ? this.getContextLimit(modelId) : 200000);
 
         debug(
           `Most recent main chain context: ${totalTokens} tokens (limit: ${contextLimit})`,
@@ -216,6 +224,7 @@ export class ContextProvider {
       hookData.transcript_path,
       hookData.model?.id,
       autocompactBuffer,
+      hookData.context_window?.context_window_size,
     );
   }
 }

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -343,5 +343,41 @@ describe("Core Functionality", () => {
         );
       expect(opusResult?.maxTokens).toBe(400000);
     });
+
+    it("should prefer Claude Code's context_window_size over modelContextLimits when current_usage is absent", async () => {
+      const transcript = [
+        '{"timestamp":"2024-01-01T10:00:00Z","message":{"usage":{"input_tokens":500000}},"isSidechain":false}',
+      ].join("\n");
+
+      const transcriptPath = join(tempDir, "test-native-limit.jsonl");
+      writeFileSync(transcriptPath, transcript);
+
+      const customConfig = {
+        ...DEFAULT_CONFIG,
+        modelContextLimits: { default: 200000, opus: 200000 },
+      };
+
+      const { ContextProvider } = require("../src/segments/context");
+      const contextProvider = new ContextProvider(customConfig);
+
+      const result = await contextProvider.getContextInfo({
+        hook_event_name: "Status",
+        session_id: "test",
+        transcript_path: transcriptPath,
+        cwd: tempDir,
+        model: { id: "claude-opus-5[1m]", display_name: "Opus 5" },
+        workspace: { current_dir: tempDir, project_dir: tempDir },
+        context_window: {
+          total_input_tokens: 500000,
+          total_output_tokens: 0,
+          context_window_size: 1000000,
+        },
+      });
+
+      expect(result).toBeDefined();
+      expect(result.totalTokens).toBe(500000);
+      expect(result.maxTokens).toBe(1000000);
+      expect(result.percentage).toBe(50);
+    });
   });
 });


### PR DESCRIPTION
## Problem

The context segment already prefers Claude Code's native `context_window` data, but `calculateContextFromHookData()` returns `null` when `current_usage` is absent — which is the case for a session with no messages yet. The transcript fallback then re-derives the limit from `modelContextLimits`, even though `context_window_size` was present in the very same payload.

Claude Code populates `context_window_size` **unconditionally** (it's `current_usage` that goes null, not the whole block), and resolves it from its own model registry. It accounts for:

- 1M-context models (`claude-opus-5`, `claude-sonnet-5` are `context: { window: 1e6, native_1m: true }`)
- the `[1m]` model suffix
- the 1M beta header on models with `supports_1m_beta`
- plan entitlement caps
- `CLAUDE_CODE_MAX_CONTEXT_TOKENS`

None of that can be inferred from the model id, so `getModelType()`'s `sonnet`/`opus` string match can't reproduce it. On a 1M model the fallback reported a 200K limit and clamped the bar to 0% remaining.

## Fix

Thread `context_window_size` into the transcript fallback and prefer it over `getContextLimit()`:

```ts
const contextLimit =
  nativeContextLimit ?? (modelId ? this.getContextLimit(modelId) : 200000);
```

`modelContextLimits` is now only consulted when Claude Code sends no `context_window` block at all, i.e. versions older than 2.0.65. It keeps working unchanged for those.

## Before / after

Same payload — `claude-opus-5[1m]`, `context_window_size: 1000000`, no `current_usage`, 500K tokens in the transcript, `modelContextLimits` at the 200K default:

```
before:  Most recent main chain context: 500000 tokens (limit: 200000)
         ◔ 500,000 (0%)     ← red, clamped

after:   Most recent main chain context: 500000 tokens (limit: 1000000)
         ◔ 500,000 (48%)
```

## Also

- README: the Model Context Limits section now leads with the fact that the window is auto-detected, and scopes `modelContextLimits` to pre-2.0.65 versions. Dropped the stale note telling users to hand-set `"sonnet": 1000000` for the tier-4 beta — that's been resolved from the hook data for a while.
- Added a test covering the native-limit-wins path; it fails without the change.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (1 pre-existing unused-var warning in `src/utils/cache.ts`, untouched)
- `npm test` — 322 passed. One pre-existing failure, `Segment Time Logic › Today Segment › should include all entries since midnight`, which is timezone-sensitive and unrelated — it fails identically on a clean `main`.

## Not addressed

The hardcoded `autocompactBuffer = 33000` is left alone. Claude Code computes its own reserve as `min(perModelBuffer, 20000)`, but that's measured against the *auto-compact window*, which isn't always the same number as the context window, and it isn't exposed in the status line payload at all. That deserves its own change.
