### PR TITLE
fix(pricing): price 1h cache writes at the cache_write_1h rate

### DIFF
--- a/src/segments/pricing.ts
+++ b/src/segments/pricing.ts
@@ -7,10 +7,22 @@ export interface ModelPricing {
   name: string;
   input: number;
   cache_write_5m: number;
-  cache_write_1h: number;
+  cache_write_1h?: number;
   cache_read: number;
   output: number;
 }
+
+interface EntryUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation?: {
+    ephemeral_1h_input_tokens?: number;
+    ephemeral_5m_input_tokens?: number;
+  };
+}
+
 const OFFLINE_PRICING_DATA: Record<string, ModelPricing> = {
   "claude-haiku-4-5-20251001": {
     name: "Claude Haiku 4.5",
@@ -405,7 +417,7 @@ export class PricingService {
     entry: Record<string, unknown>,
   ): Promise<number> {
     const message = entry.message as Record<string, unknown> | undefined;
-    const usage = message?.usage as Record<string, number> | undefined;
+    const usage = message?.usage as EntryUsage | undefined;
     if (!usage) {
       return 0;
     }
@@ -418,11 +430,23 @@ export class PricingService {
     const cacheCreationTokens = usage.cache_creation_input_tokens || 0;
     const cacheReadTokens = usage.cache_read_input_tokens || 0;
 
+    const cacheCreation = usage.cache_creation;
+    const oneHourTokens = cacheCreation?.ephemeral_1h_input_tokens ?? 0;
+    const explicitFiveMinuteTokens =
+      cacheCreation?.ephemeral_5m_input_tokens ?? 0;
+    const uncategorizedFiveMinuteTokens = Math.max(
+      0,
+      cacheCreationTokens - oneHourTokens - explicitFiveMinuteTokens,
+    );
+    const cacheWrite1hRate = pricing.cache_write_1h ?? pricing.cache_write_5m;
+
     const inputCost = (inputTokens / 1_000_000) * pricing.input;
     const outputCost = (outputTokens / 1_000_000) * pricing.output;
     const cacheReadCost = (cacheReadTokens / 1_000_000) * pricing.cache_read;
     const cacheCreationCost =
-      (cacheCreationTokens / 1_000_000) * pricing.cache_write_5m;
+      (oneHourTokens / 1_000_000) * cacheWrite1hRate +
+      ((explicitFiveMinuteTokens + uncategorizedFiveMinuteTokens) / 1_000_000) *
+        pricing.cache_write_5m;
 
     return inputCost + outputCost + cacheCreationCost + cacheReadCost;
   }

--- a/test/pricing.test.ts
+++ b/test/pricing.test.ts
@@ -1,0 +1,120 @@
+import { PricingService } from "../src/segments/pricing";
+import type { ModelPricing } from "../src/segments/pricing";
+
+describe("PricingService cache write pricing", () => {
+  const mockPricing: ModelPricing = {
+    name: "Test Model",
+    input: 10,
+    output: 20,
+    cache_write_5m: 1,
+    cache_write_1h: 4,
+    cache_read: 0.5,
+  };
+
+  let getModelPricingSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    getModelPricingSpy = jest
+      .spyOn(PricingService, "getModelPricing")
+      .mockResolvedValue(mockPricing);
+  });
+
+  afterEach(() => {
+    getModelPricingSpy.mockRestore();
+  });
+
+  const entryWithUsage = (usage: Record<string, unknown>) => ({
+    model: "test-model",
+    message: { usage },
+  });
+
+  test.each([
+    {
+      case: "legacy aggregate only (no cache_creation breakdown) uses 5m rate",
+      usage: { cache_creation_input_tokens: 1_000_000 },
+      expected: 1,
+    },
+    {
+      case: "1h-only breakdown uses 1h rate",
+      usage: {
+        cache_creation_input_tokens: 1_000_000,
+        cache_creation: { ephemeral_1h_input_tokens: 1_000_000 },
+      },
+      expected: 4,
+    },
+    {
+      case: "5m-only breakdown uses 5m rate",
+      usage: {
+        cache_creation_input_tokens: 1_000_000,
+        cache_creation: { ephemeral_5m_input_tokens: 1_000_000 },
+      },
+      expected: 1,
+    },
+    {
+      case: "mixed breakdown prices each bucket at its own rate",
+      usage: {
+        cache_creation_input_tokens: 3_000_000,
+        cache_creation: {
+          ephemeral_1h_input_tokens: 2_000_000,
+          ephemeral_5m_input_tokens: 1_000_000,
+        },
+      },
+      expected: 2 * 4 + 1 * 1,
+    },
+    {
+      case: "partial breakdown prices the uncategorized residual at 5m rate",
+      usage: {
+        cache_creation_input_tokens: 3_000_000,
+        cache_creation: { ephemeral_1h_input_tokens: 1_000_000 },
+      },
+      expected: 1 * 4 + 2 * 1,
+    },
+    {
+      case: "breakdown larger than aggregate does not go negative",
+      usage: {
+        cache_creation_input_tokens: 1_000_000,
+        cache_creation: {
+          ephemeral_1h_input_tokens: 1_000_000,
+          ephemeral_5m_input_tokens: 1_000_000,
+        },
+      },
+      expected: 1 * 4 + 1 * 1,
+    },
+  ])("$case", async ({ usage, expected }) => {
+    const cost = await PricingService.calculateCostForEntry(
+      entryWithUsage(usage),
+    );
+    expect(cost).toBeCloseTo(expected, 10);
+  });
+
+  test("missing cache_write_1h rate falls back to the 5m rate", async () => {
+    const { cache_write_1h: _unused, ...withoutOneHourRate } = mockPricing;
+    getModelPricingSpy.mockResolvedValue(withoutOneHourRate);
+
+    const cost = await PricingService.calculateCostForEntry(
+      entryWithUsage({
+        cache_creation_input_tokens: 1_000_000,
+        cache_creation: { ephemeral_1h_input_tokens: 1_000_000 },
+      }),
+    );
+
+    expect(cost).toBeCloseTo(1, 10);
+  });
+
+  test("cache costs combine with input, output, and cache read costs", async () => {
+    const cost = await PricingService.calculateCostForEntry(
+      entryWithUsage({
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+        cache_read_input_tokens: 1_000_000,
+        cache_creation_input_tokens: 2_000_000,
+        cache_creation: {
+          ephemeral_1h_input_tokens: 1_000_000,
+          ephemeral_5m_input_tokens: 1_000_000,
+        },
+      }),
+    );
+
+    expect(cost).toBeCloseTo(10 + 20 + 0.5 + 4 + 1, 10);
+  });
+});


### PR DESCRIPTION
Fixes #104.

`calculateCostForEntry` priced all of `cache_creation_input_tokens` at the 5-minute rate; the `cache_write_1h` rate was loaded but never read. Entries carry the split under `usage.cache_creation.{ephemeral_1h_input_tokens, ephemeral_5m_input_tokens}`, so the cost now prices each portion at its own rate. Anything not covered by the split falls back to the 5-minute rate, which keeps old records at their current behavior, and a missing `cache_write_1h` rate falls back to the 5m rate rather than NaN. Tests in `test/pricing.test.ts` run against mocked rates.