### PR TITLE
fix(tui): honor session costSource in TUI renderers

### DIFF
--- a/src/tui/layouts.ts
+++ b/src/tui/layouts.ts
@@ -18,6 +18,7 @@ import {
   formatWeeklySegment,
   formatSessionSegment,
   formatTodaySegment,
+  resolveSessionCost,
 } from "./sections";
 
 // --- Wide layout (80+ cols): metrics on 1 line, workspace+footer on 1 line ---
@@ -250,9 +251,10 @@ export function renderNarrowMetrics(ctx: RenderCtx): void {
 
   const sessionAndToday: string[] = [];
   if (data.usageInfo) {
+    const sessionCost = resolveSessionCost(data.usageInfo.session, config);
     const sessionText = showSessionIcon
-      ? `${sym.session_cost} ${formatCost(data.usageInfo.session.cost)}`
-      : formatCost(data.usageInfo.session.cost);
+      ? `${sym.session_cost} ${formatCost(sessionCost)}`
+      : formatCost(sessionCost);
     sessionAndToday.push(
       colorize(sessionText, colors.sessionFg, reset, colors.sessionBold),
     );

--- a/src/tui/sections.ts
+++ b/src/tui/sections.ts
@@ -1,4 +1,4 @@
-import type { PowerlineConfig } from "../config/loader";
+import type { LineConfig, PowerlineConfig } from "../config/loader";
 import type { PowerlineColors } from "../themes";
 import type {
   TuiData,
@@ -31,6 +31,7 @@ import { resolveBudgetDisplay } from "../utils/budget";
 import type {
   CacheTimerSegmentConfig,
   OutputStyleSegmentConfig,
+  UsageSegmentConfig,
 } from "../segments/renderer";
 import { segmentPartNames } from "./types";
 import { colorize, truncateAnsi } from "./primitives";
@@ -623,14 +624,43 @@ export function formatWeeklySegment(
   return text;
 }
 
+/** Find a segment's config across lines: enabled entry first, then any configured entry. */
+function findConfiguredSegment<K extends keyof LineConfig["segments"]>(
+  config: PowerlineConfig,
+  key: K,
+): LineConfig["segments"][K] {
+  const configured = config.display.lines.map((line) => line.segments[key]);
+  return (
+    configured.find((segment) => segment?.enabled) ??
+    configured.find((segment) => segment !== undefined)
+  );
+}
+
+export function getSessionSegmentConfig(
+  config: PowerlineConfig,
+): UsageSegmentConfig | undefined {
+  return findConfiguredSegment(config, "session");
+}
+
+export function resolveSessionCost(
+  session: (TuiData["usageInfo"] & {})["session"],
+  config: PowerlineConfig,
+): number | null {
+  const costSource = getSessionSegmentConfig(config)?.costSource;
+  if (costSource === "calculated") return session.calculatedCost;
+  if (costSource === "official") return session.officialCost;
+  return session.cost;
+}
+
 export function formatSessionParts(
   usageInfo: TuiData["usageInfo"] & {},
   sym: SymbolSet,
   config: PowerlineConfig,
   iconVisible = true,
 ): SegmentParts<"session"> {
+  const sessionCost = resolveSessionCost(usageInfo.session, config);
   const state = resolveBudgetDisplay(
-    usageInfo.session.cost,
+    sessionCost,
     usageInfo.session.tokens,
     config.budget?.session,
   );
@@ -648,7 +678,7 @@ export function formatSessionParts(
   return {
     icon: iconVisible ? sym.session_cost : "",
     label: state.percentageOnly ? "" : "session",
-    cost: state.showBase ? formatCost(usageInfo.session.cost) : "",
+    cost: state.showBase ? formatCost(sessionCost) : "",
     tokens: tokenStr,
     budget: state.percentText ? ` ${state.percentText}` : "",
   };
@@ -660,8 +690,9 @@ export function formatSessionSegment(
   config: PowerlineConfig,
   iconVisible = true,
 ): string {
+  const sessionCost = resolveSessionCost(usageInfo.session, config);
   const state = resolveBudgetDisplay(
-    usageInfo.session.cost,
+    sessionCost,
     usageInfo.session.tokens,
     config.budget?.session,
   );
@@ -673,7 +704,7 @@ export function formatSessionSegment(
     return icon ? `${icon} ${state.percentText}` : state.percentText;
   }
 
-  const costStr = formatCost(usageInfo.session.cost);
+  const costStr = formatCost(sessionCost);
   const sessionTokens = usageInfo.session.tokens;
   let text = icon ? `${icon} ${costStr}` : costStr;
   if (sessionTokens !== null && sessionTokens > 0) {
@@ -1058,13 +1089,7 @@ function formatOutputStyleSegment(
 function getOutputStyleConfig(
   config: PowerlineConfig,
 ): OutputStyleSegmentConfig | undefined {
-  const configured = config.display.lines.map(
-    (line) => line.segments.outputStyle,
-  );
-  return (
-    configured.find((segment) => segment?.enabled) ??
-    configured.find((segment) => segment !== undefined)
-  );
+  return findConfiguredSegment(config, "outputStyle");
 }
 
 function buildThinkingBody(

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -5,6 +5,8 @@ import {
   resolveSegments,
   formatTodayParts,
   formatSessionParts,
+  formatSessionSegment,
+  getSessionSegmentConfig,
 } from "../src/tui/sections";
 import type { TuiData, BoxChars, RenderCtx } from "../src/tui/types";
 import { isValidSegmentRef, SEGMENT_PARTS } from "../src/tui/types";
@@ -969,6 +971,101 @@ describe("TUI Panel Rendering", () => {
         cost: "",
         tokens: "",
         budget: "",
+      });
+    });
+  });
+
+  describe("Session costSource (TUI)", () => {
+    const officialConfig: PowerlineConfig = {
+      ...DEFAULT_CONFIG,
+      display: {
+        ...DEFAULT_CONFIG.display,
+        style: "tui",
+        lines: [
+          {
+            segments: {
+              ...DEFAULT_CONFIG.display.lines[0]!.segments,
+              session: { enabled: true, type: "cost", costSource: "official" },
+            },
+          },
+        ],
+      },
+      budget: {
+        session: { amount: 10, warningThreshold: 80 },
+      },
+    };
+
+    const usageInfo = {
+      session: {
+        cost: 1.25,
+        calculatedCost: 1.25,
+        officialCost: 5,
+        tokens: 100,
+        tokenBreakdown: null,
+      },
+    };
+
+    it("formatSessionParts uses officialCost for cost and budget percentage", () => {
+      const parts = formatSessionParts(
+        usageInfo as any,
+        SYMBOLS as any,
+        officialConfig,
+        true,
+      );
+      expect(parts.cost).toBe("$5.00");
+      // 5 / 10 = 50%, not 1.25 / 10 = 13%
+      expect(parts.budget).toContain("50%");
+    });
+
+    it("formatSessionSegment uses officialCost for cost and budget percentage", () => {
+      const text = formatSessionSegment(
+        usageInfo as any,
+        SYMBOLS as any,
+        officialConfig,
+        true,
+      );
+      expect(text).toContain("$5.00");
+      expect(text).toContain("50%");
+    });
+
+    it("narrow layout uses officialCost", async () => {
+      const result = await renderTuiPanel(
+        makeTuiData({ usageInfo }),
+        BOX_CHARS,
+        "",
+        40,
+        officialConfig,
+      );
+      expect(result).toContain("$5.00");
+      expect(result).not.toContain("$1.25");
+    });
+
+    it("getSessionSegmentConfig prefers the enabled entry over earlier disabled ones", () => {
+      const config: PowerlineConfig = {
+        ...officialConfig,
+        display: {
+          ...officialConfig.display,
+          lines: [
+            {
+              segments: {
+                session: {
+                  enabled: false,
+                  type: "cost",
+                  costSource: "official",
+                },
+              },
+            },
+            {
+              segments: {
+                session: { enabled: true, type: "cost" },
+              },
+            },
+          ],
+        },
+      };
+      expect(getSessionSegmentConfig(config)).toEqual({
+        enabled: true,
+        type: "cost",
       });
     });
   });


### PR DESCRIPTION
Fixes #105.

The classic renderer resolves `session.costSource`; the TUI renderer never read it. Both session formatters and the narrow layout took `session.cost` directly. They now share a `resolveSessionCost` helper that mirrors the classic `getCost` exactly, and the resolved value feeds both the visible cost and the budget percentage so the two cannot disagree. Session segment config is looked up with the same precedence as the other TUI config helpers. Tests cover both formatters and the narrow layout.