### PR TITLE
fix(context): model current_usage as nullable in hook payload

### DIFF
--- a/src/segments/context.ts
+++ b/src/segments/context.ts
@@ -83,7 +83,9 @@ export class ContextProvider {
 
   /**
    * Calculate context info from native Claude Code context_window data (preferred).
-   * Requires Claude Code 2.0.70+ with current_usage field.
+   * Requires Claude Code 2.0.70+ with current_usage field. Claude Code sets
+   * current_usage to null before the first API call in a session and again
+   * right after /compact until the next API call.
    */
   calculateContextFromHookData(
     hookData: ClaudeHookData,

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -40,7 +40,7 @@ export interface ClaudeHookData {
       output_tokens: number;
       cache_creation_input_tokens: number;
       cache_read_input_tokens: number;
-    };
+    } | null;
   };
   exceeds_200k_tokens?: boolean;
   rate_limits?: {

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -344,7 +344,7 @@ describe("Core Functionality", () => {
       expect(opusResult?.maxTokens).toBe(400000);
     });
 
-    it("should prefer Claude Code's context_window_size over modelContextLimits when current_usage is absent", async () => {
+    it("should prefer Claude Code's context_window_size over modelContextLimits when current_usage is null", async () => {
       const transcript = [
         '{"timestamp":"2024-01-01T10:00:00Z","message":{"usage":{"input_tokens":500000}},"isSidechain":false}',
       ].join("\n");
@@ -371,6 +371,7 @@ describe("Core Functionality", () => {
           total_input_tokens: 500000,
           total_output_tokens: 0,
           context_window_size: 1000000,
+          current_usage: null,
         },
       });
 
@@ -378,6 +379,9 @@ describe("Core Functionality", () => {
       expect(result.totalTokens).toBe(500000);
       expect(result.maxTokens).toBe(1000000);
       expect(result.percentage).toBe(50);
+      expect(result.usableTokens).toBe(967000);
+      expect(result.usablePercentage).toBe(52);
+      expect(result.contextLeftPercentage).toBe(48);
     });
   });
 });


### PR DESCRIPTION
Follow-up to #107, from its review. The statusline docs define `context_window.current_usage` as explicitly `null` (before the first API call, and right after `/compact`), not just absent. This models the field as nullable, makes the regression test feed a real `null`, and asserts the derived usable-token values. No runtime change; the existing `!currentUsage` guard already treats null and undefined the same.

@cblecker is kept as the commit author since this rounds out their PR.